### PR TITLE
docs: Add mbox split script and README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,16 @@ A powerful command-line tool for exporting, importing, and managing Gmail emails
 
 - **Export emails** from Gmail with advanced filtering (supports all Gmail search operators)
 - **Import emails** into Gmail accounts (supports cross-account transfers)
-- **Cleanup emails** from source account after export
+- **Preserve labels** from original emails (via X-Gmail-Labels header)
+- **Avoid duplicates** during import with Message-ID checking
+- **Cleanup emails** from source account after migration (archive or delete)
 - **Multiple formats**: EML, JSON, mbox
 - **Parallel processing** for high performance
 - **Progress tracking** with real-time indicators
 - **Resumable operations** with state management
-- **Comprehensive metrics** collection (JSON and Prometheus formats)
+- **Comprehensive metrics** collection (JSON and Prometheus)
 - **OAuth 2.0 authentication** with Google Gmail API
+- **Mbox helper script** (`split-mbox-emails.py`) to split mbox files for importing
 - **Cross-account support** for migrating between Gmail accounts
 
 ## Installation
@@ -124,27 +127,53 @@ For migrating emails between different Gmail accounts:
 
 ### Cross-Account Migration
 
+For migrating emails between different Gmail accounts:
+
 ```bash
 # 1. Export from source account
 ./gmail-exporter export \
   --credentials-file source-creds.json \
   --token-file source-token.json \
-  --output-dir migration/ \
-  --search-scope "all_mail"
+  --output-dir migration-exports \
+  --format eml
 
 # 2. Import to destination account
 ./gmail-exporter import \
-  --input-dir migration/ \
+  --input-dir migration-exports \
   --import-credentials dest-creds.json \
   --import-token dest-token.json
+```
 
-# 3. Optional: Clean up source account
-# Note: The export process automatically creates processed_emails.json
-./gmail-exporter cleanup \
-  --credentials-file source-creds.json \
-  --token-file source-token.json \
-  --action archive \
-  --filter-file migration/processed_emails.json
+### Import Mbox Files
+
+When importing mbox files, first split them into individual emails:
+
+```bash
+# Split mbox into individual .eml files
+./split-mbox-emails.py backups/my_emails.mbox backups/split
+
+# Import the split emails
+./gmail-exporter import --input-dir backups/split
+```
+
+**Mbox Import Options:**
+
+```bash
+# Import with label preservation (emails with X-Gmail-Labels header)
+./split-mbox-emails.py backups/my_emails.mbox backups/split
+./gmail-exporter import --input-dir backups/split
+
+# Import with custom labels (overrides email labels)
+./split-mbox-emails.py backups/my_emails.mbox backups/split
+./gmail-exporter import --input-dir backups/split --labels "tickets,work"
+
+# Import with deduplication (skip emails already in Gmail)
+./split-mbox-emails.py backups/my_emails.mbox backups/split
+./gmail-exporter import --input-dir backups/split --skip-duplicates
+
+# Test import with limit first
+./split-mbox-emails.py backups/my_emails.mbox backups/split
+./gmail-exporter import --input-dir backups/split --limit 5
 ```
 
 ### Generate Filter File from Existing Exports
@@ -224,19 +253,28 @@ All Gmail search operators are supported:
 - `--labels`: Specific labels (comma-separated)
 - `--search-scope`: Search scope (all_mail, inbox, sent, drafts, spam, trash)
 
-## Output Formats
+### Output Formats
 
 ### EML Format (Default)
-
 Standard email format that preserves all email data including headers, body, and attachments.
 
 ### JSON Format
-
-Structured format containing the complete Gmail API message object.
+Structured format containing the complete Gmail API message object, useful for programmatic processing.
 
 ### Mbox Format
+Unix mailbox format for compatibility with email clients. Contains multiple emails in a single file.
 
-Unix mailbox format for compatibility with email clients.
+**⚠️ Important:** Mbox files must be split into individual .eml files before importing. Use the provided `split-mbox-emails.py` helper script:
+
+```bash
+# Split mbox file into individual emails
+./split-mbox-emails.py exports/my_emails.mbox exports/split
+
+# Now import the individual emails
+./gmail-exporter import --input-dir exports/split
+```
+
+See [USAGE.md](USAGE.md) for more details on importing mbox files.
 
 ## Security and Privacy
 
@@ -306,7 +344,16 @@ The tool collects comprehensive metrics:
     "bytes_per_second": 6553600
   }
 }
-```
+  ```
+
+## Tools
+
+- **`gmail-exporter`**: Main CLI application
+- **`split-mbox-emails.py`**: Helper script to split mbox files into individual .eml files for importing
+  - Validates mbox format before processing
+  - Handles empty messages and malformed mbox files gracefully
+  - Supports verbose mode (`-v` or `--verbose`) for debugging
+  - Usage: `./split-mbox-emails.py <mbox_file> [output_dir] [options]`
 
 ## Contributing
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -137,24 +137,29 @@ credentials_file: "~/.gmail-exporter/credentials.json"
 token_file: "~/.gmail-exporter/token.json"
 
 # Default Export Settings
-output_dir: "./exports"
-organize_by_labels: false
-parallel_workers: 3
+ output_dir: "./exports"
+ organize_by_labels: false
+ parallel_workers: 3
 
 # Default Filters
-filters:
+ filters:
   exclude_chats: true
   search_scope: "all_mail"
 
 # Metrics Configuration
-metrics:
-  enabled: true
-  format: "json"
-  output_file: "metrics.json"
+ metrics:
+   enabled: true
+   format: "json"
+   output_file: "metrics.json"
 
 # Logging
-log_level: "info"
-log_file: ""
+ log_level: "info"
+ log_file: ""
+
+# Import Settings (optional)
+# skip_duplicates: false  # Skip emails already in Gmail (based on Message-ID)
+# labels: ""  # Override email labels (comma-separated)
+```
 ```
 
 ## Step 7: Monitoring and Metrics
@@ -178,6 +183,124 @@ After an export operation, check the metrics file:
 ```bash
 cat ./exports/metrics.json
 ```
+
+## Import Usage
+
+The import command allows you to import previously exported emails into a Gmail account. This is useful for:
+- Migrating emails between Gmail accounts
+- Restoring emails from backups
+- Importing emails from other email systems (after export)
+- Testing import functionality
+
+### Basic Import
+
+```bash
+./gmail-exporter import --input-dir ./exports
+```
+
+### Import with Label Preservation
+
+Emails exported from Gmail contain `X-Gmail-Labels` headers. The importer automatically extracts these labels and applies them during import:
+
+```bash
+./gmail-exporter import --input-dir ./exports
+```
+
+Labels are automatically:
+- Extracted from `X-Gmail-Labels` header
+- Normalized to Gmail API format (e.g., "Category Personal" → "CATEGORY_PERSONAL")
+- Resolved to actual Gmail label IDs
+
+### Import with Custom Labels
+
+Override email labels with your own labels:
+
+```bash
+./gmail-exporter import \
+  --input-dir ./exports \
+  --labels "important,work,projects"
+```
+
+This is useful when:
+- You want to reorganize emails during import
+- Exported emails have missing or incorrect labels
+- Migrating to a different label structure
+
+### Import with Deduplication
+
+Avoid importing duplicate emails by checking Message-ID against Gmail before importing:
+
+```bash
+./gmail-exporter import \
+  --input-dir ./exports \
+  --skip-duplicates
+```
+
+**When to use `--skip-duplicates`:**
+- Re-running imports after failures
+- Testing import process multiple times
+- Importing from multiple mbox files that may overlap
+- Any scenario where you might run import twice on the same data
+
+**How deduplication works:**
+1. Extracts `Message-ID` from email headers (RFC 5322 format)
+2. Queries Gmail API with `rfc822msgid:<id>` to check if message exists
+3. Skips import if message already found in Gmail
+4. Reports count of skipped duplicates in output
+
+### Complete Import Workflow
+
+Here's a complete workflow for migrating emails from one account to another:
+
+```bash
+# Step 1: Export from source account
+./gmail-exporter export \
+  --to "old-account@gmail.com" \
+  --output-dir migration-exports \
+  --organize-by-labels
+
+# Step 2: Test import with a few messages
+./gmail-exporter import \
+  --input-dir migration-exports \
+  --limit 10 \
+  --skip-duplicates
+
+# Step 3: If test successful, import all
+./gmail-exporter import \
+  --input-dir migration-exports \
+  --skip-duplicates \
+  --parallel-workers 3
+```
+
+### Import Configuration
+
+You can set import-specific options in your config file:
+
+```yaml
+# ~/.gmail-exporter.yaml
+import:
+  input_dir: "./exports"
+  parallel_workers: 3
+  preserve_dates: true
+  skip_duplicates: false  # Enable to avoid duplicates
+  labels: ""  # Override with comma-separated labels
+```
+
+### Import Metrics
+
+After import completes, check the metrics file:
+
+```bash
+cat import_metrics.json
+```
+
+This includes:
+- `total_found`: Total files processed
+- `total_imported`: Successfully imported emails
+- `total_failed`: Failed imports
+- `total_skipped`: Duplicates skipped (with --skip-duplicates)
+- `total_size`: Total size imported
+- `duration`: Time taken
 
 ## Common Use Cases
 
@@ -214,10 +337,13 @@ cat ./exports/metrics.json
 
 ```bash
 ./gmail-exporter export \
+  --to "user@example.com" \
   --labels "important,work" \
   --organize-by-labels \
   --output-dir ./labeled-emails
 ```
+
+**Note:** Labels are preserved in exports via `X-Gmail-Labels` header and will be automatically applied when importing to another Gmail account.
 
 ### 5. Complete Workflow (Export + Forward + Archive)
 
@@ -227,6 +353,27 @@ cat ./exports/metrics.json
   --destination "backup@example.com" \
   --cleanup-action archive \
   --output-dir ./exports
+```
+
+### 6. Safe Import Testing
+
+When testing imports, use deduplication to avoid creating test duplicates in Gmail:
+
+```bash
+# First, export a small test set
+./gmail-exporter export \
+  --to "test@example.com" \
+  --limit 5 \
+  --output-dir test-exports
+
+# Test import with deduplication enabled
+./gmail-exporter import \
+  --input-dir test-exports \
+  --skip-duplicates \
+  --limit 5
+
+# If successful, you can re-run import without --skip-duplicates on the full export
+# without creating duplicate emails
 ```
 
 ## Troubleshooting
@@ -288,11 +435,24 @@ For large exports:
 | `--size-less-than` | Email size threshold | `--size-less-than "10MB"` |
 | `--date-within` | Date range | `--date-within "30d"` |
 | `--date-after` | After specific date | `--date-after "2024-01-01"` |
-| `--date-before` | Before specific date | `--date-before "2024-12-31"` |
+ | `--date-before` | Before specific date | `--date-before "2024-12-31"` |
 | `--has-attachment` | Has attachments | `--has-attachment` |
 | `--no-attachment` | No attachments | `--no-attachment` |
 | `--exclude-chats` | Exclude chat messages | `--exclude-chats` |
 | `--labels` | Specific labels | `--labels "important,work"` |
+
+## Import Filter Reference
+
+| Flag | Description | Example |
+|--------|-------------|---------|
+| `--input-dir` | Input directory containing exported emails | `--input-dir ./exports` |
+| `--import-credentials` | Gmail API credentials file for destination account | `--import-credentials dest-creds.json` |
+| `--import-token` | OAuth token file for destination account | `--import-token dest-token.json` |
+| `--parallel-workers` | Number of parallel workers | `--parallel-workers 3` |
+| `--preserve-dates` | Preserve original email dates | `--preserve-dates` |
+| `--limit` | Limit to number of messages to process | `--limit 100` |
+| `--labels` | Gmail labels to apply to imported emails (overrides X-Gmail-Labels header) | `--labels "tickets,music"` |
+| `--skip-duplicates` | Skip emails that already exist in Gmail (based on Message-ID) | `--skip-duplicates` |
 
 ## Security Notes
 
@@ -381,7 +541,8 @@ Here's a complete example of migrating emails from one account to another:
   --import-credentials dest-gmail-credentials.json \
   --import-token dest-gmail-token.json \
   --limit 5 \
-  --preserve-dates
+  --preserve-dates \
+  --skip-duplicates
 
 # Step 3: If test successful, import all
 ./gmail-exporter import \
@@ -389,15 +550,8 @@ Here's a complete example of migrating emails from one account to another:
   --import-credentials dest-gmail-credentials.json \
   --import-token dest-gmail-token.json \
   --preserve-dates \
+  --skip-duplicates \
   --parallel-workers 3
-
-# Step 4: Optional - Clean up source account
-./gmail-exporter cleanup \
-  --credentials-file source-gmail-credentials.json \
-  --token-file source-gmail-token.json \
-  --action archive \
-  --filter-file migration-2024/processed_emails.json \
-  --dry-run  # Remove this flag when ready to execute
 ```
 
 ### Account-Specific Configuration
@@ -566,15 +720,21 @@ Before running large migrations:
 ### Import Issues
 
 **Problem:** Emails not appearing in destination account
-
 - Verify you're using correct destination credentials
 - Check that import completed without errors
 - Look in "All Mail" folder, not just Inbox
 
 **Problem:** Duplicate emails during import
+- Use `--skip-duplicates` flag to avoid importing emails that already exist in Gmail
+- This checks for duplicates by Message-ID before importing
+- Useful when re-running imports after failures or testing
+- With `--skip-duplicates` enabled, check output for "Total emails skipped (duplicates)" count
 
-- This was a bug in earlier versions - ensure you're using latest version
-- The tool now uses Gmail API Import instead of Send
+**Problem:** Labels not being applied
+- Ensure emails have `X-Gmail-Labels` header when exported
+- Check that label names match your Gmail labels (case-sensitive)
+- Use `--labels` flag to override email labels if needed
+- Labels like "Archived" and "Opened" are skipped (they're not Gmail labels)
 
 ### Performance Issues
 

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -23,8 +23,13 @@ The import command uses separate credentials from export to allow importing into
 Gmail account. Use --import-credentials and --import-token to specify different authentication
 files for the destination account.
 
+LABELS:
+Use --labels to apply Gmail labels to imported emails. Labels are specified as a
+comma-separated list of label names (e.g., --labels "tickets,music"). The tool will
+automatically resolve label names to their corresponding Gmail label IDs.
+
 Use --limit to process only a specific number of messages, which is useful for testing
-the import process with a small number of messages before running a full import.`,
+import process with a small number of messages before running a full import.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Build import configuration from flags
 		importConfig, err := buildImportConfig(cmd)
@@ -72,6 +77,7 @@ func init() {
 	importCmd.Flags().Int("parallel-workers", 3, "Number of parallel workers")
 	importCmd.Flags().Bool("preserve-dates", true, "Preserve original email dates")
 	importCmd.Flags().IntP("limit", "l", 0, "Limit the number of messages to process (0 = no limit, useful for testing)")
+	importCmd.Flags().String("labels", "", "Gmail labels to apply to imported emails (comma-separated)")
 }
 
 func buildImportConfig(cmd *cobra.Command) (*importer.Config, error) {
@@ -104,6 +110,9 @@ func buildImportConfig(cmd *cobra.Command) (*importer.Config, error) {
 	}
 	if limit, _ := cmd.Flags().GetInt("limit"); limit > 0 {
 		config.Limit = limit
+	}
+	if labels, _ := cmd.Flags().GetString("labels"); labels != "" {
+		config.Labels = labels
 	}
 
 	// Validate required fields

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -28,8 +28,13 @@ Use --labels to apply Gmail labels to imported emails. Labels are specified as a
 comma-separated list of label names (e.g., --labels "tickets,music"). The tool will
 automatically resolve label names to their corresponding Gmail label IDs.
 
+DEDUPLICATION:
+Use --skip-duplicates to avoid importing emails that already exist in Gmail. This checks
+for existing messages by Message-ID before importing. Enabling this will skip duplicates
+and log the count of skipped messages.
+
 Use --limit to process only a specific number of messages, which is useful for testing
-import process with a small number of messages before running a full import.`,
+-import process with a small number of messages before running a full import.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Build import configuration from flags
 		importConfig, err := buildImportConfig(cmd)
@@ -59,6 +64,9 @@ import process with a small number of messages before running a full import.`,
 		fmt.Printf("Import completed successfully!\n")
 		fmt.Printf("Total files found: %d\n", result.TotalFound)
 		fmt.Printf("Total emails imported: %d\n", result.TotalImported)
+		if result.TotalSkipped > 0 {
+			fmt.Printf("Total emails skipped (duplicates): %d\n", result.TotalSkipped)
+		}
 		fmt.Printf("Total size: %s\n", metrics.FormatBytes(result.TotalSize))
 		fmt.Printf("Duration: %s\n", result.Duration)
 
@@ -78,6 +86,7 @@ func init() {
 	importCmd.Flags().Bool("preserve-dates", true, "Preserve original email dates")
 	importCmd.Flags().IntP("limit", "l", 0, "Limit the number of messages to process (0 = no limit, useful for testing)")
 	importCmd.Flags().String("labels", "", "Gmail labels to apply to imported emails (comma-separated)")
+	importCmd.Flags().Bool("skip-duplicates", false, "Skip emails that already exist in Gmail (based on Message-ID)")
 }
 
 func buildImportConfig(cmd *cobra.Command) (*importer.Config, error) {
@@ -113,6 +122,9 @@ func buildImportConfig(cmd *cobra.Command) (*importer.Config, error) {
 	}
 	if labels, _ := cmd.Flags().GetString("labels"); labels != "" {
 		config.Labels = labels
+	}
+	if skipDuplicates, _ := cmd.Flags().GetBool("skip-duplicates"); skipDuplicates {
+		config.SkipDuplicates = skipDuplicates
 	}
 
 	// Validate required fields

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -27,6 +27,7 @@ type Config struct {
 	PreserveDates   bool   `json:"preserve_dates"`
 	Limit           int    `json:"limit"`
 	Labels          string `json:"labels"`
+	SkipDuplicates  bool   `json:"skip_duplicates"`
 }
 
 // Result represents the import operation result
@@ -34,6 +35,7 @@ type Result struct {
 	TotalFound    int           `json:"total_found"`
 	TotalImported int           `json:"total_imported"`
 	TotalFailed   int           `json:"total_failed"`
+	TotalSkipped  int           `json:"total_skipped"`
 	TotalSize     int64         `json:"total_size"`
 	Duration      time.Duration `json:"duration"`
 	Failures      []Failure     `json:"failures,omitempty"`
@@ -222,14 +224,19 @@ func (i *Importer) importEmails(emailFiles []string) (*Result, error) {
 				Timestamp: time.Now(),
 			})
 			logrus.WithError(importRes.Error).WithField("file_path", importRes.FilePath).Error("Failed to import email")
+		} else if importRes.Size == 0 {
+			// Email was skipped (e.g., duplicate)
+			result.TotalSkipped++
+			logrus.WithField("file_path", importRes.FilePath).Debug("Skipped email")
 		} else {
 			result.TotalImported++
 			result.TotalSize += importRes.Size
 		}
 
-		// Show progress
-		fmt.Printf("\rProgress: %d of %d messages imported (%.1f%%)",
-			result.TotalImported, total, float64(processed)/float64(total)*100)
+		// Show progress (imported + skipped)
+		completed := result.TotalImported + result.TotalSkipped
+		fmt.Printf("\rProgress: %d of %d messages processed (%.1f%%)",
+			completed, total, float64(processed)/float64(total)*100)
 	}
 	fmt.Println() // New line after progress
 
@@ -284,6 +291,20 @@ func (i *Importer) importEMLFile(data []byte) (int64, error) {
 	// Extract labels from email headers
 	labelIds := i.getLabelIdsForEmail(data)
 
+	// Check for duplicates if enabled
+	if i.config.SkipDuplicates {
+		messageID := i.extractMessageID(data)
+		if messageID != "" {
+			exists, err := i.messageExists(messageID)
+			if err != nil {
+				logrus.WithError(err).WithField("message_id", messageID).Warn("Failed to check if message exists, proceeding with import")
+			} else if exists {
+				logrus.WithField("message_id", messageID).Info("Message already exists in Gmail, skipping")
+				return 0, nil
+			}
+		}
+	}
+
 	// Create a Gmail message from the EML data
 	message := &gmail.Message{
 		Raw:      encodeBase64URL(data),
@@ -316,6 +337,21 @@ func (i *Importer) importJSONFile(data []byte) (int64, error) {
 		// If decoding fails, just use the raw as-is
 		rawBytes = []byte(emailData.Raw)
 	}
+
+	// Check for duplicates if enabled
+	if i.config.SkipDuplicates {
+		messageID := i.extractMessageID(rawBytes)
+		if messageID != "" {
+			exists, err := i.messageExists(messageID)
+			if err != nil {
+				logrus.WithError(err).WithField("message_id", messageID).Warn("Failed to check if message exists, proceeding with import")
+			} else if exists {
+				logrus.WithField("message_id", messageID).Info("Message already exists in Gmail, skipping")
+				return 0, nil
+			}
+		}
+	}
+
 	labelIds := i.getLabelIdsForEmail(rawBytes)
 
 	// Create a Gmail message
@@ -543,6 +579,67 @@ func validateConfig(config *Config) error {
 	}
 
 	return nil
+}
+
+// extractMessageID extracts the Message-ID header from email data
+func (i *Importer) extractMessageID(data []byte) string {
+	dataStr := string(data)
+
+	// Find the Message-ID header
+	headerPrefix := "\nMessage-ID:"
+	idx := strings.Index(dataStr, headerPrefix)
+	if idx == -1 {
+		// Try with lowercase
+		headerPrefix = "\nmessage-id:"
+		idx = strings.Index(dataStr, headerPrefix)
+		if idx == -1 {
+			return ""
+		}
+	}
+
+	// Extract the header value (up to the next line)
+	start := idx + len(headerPrefix)
+	end := len(dataStr)
+
+	for i := start; i < len(dataStr); i++ {
+		if dataStr[i] == '\n' {
+			end = i
+			break
+		}
+	}
+
+	messageID := strings.TrimSpace(dataStr[start:end])
+
+	// Remove angle brackets and any trailing parameters
+	messageID = strings.Trim(messageID, "<>")
+
+	// Extract just the ID part before parameters (like ; or space)
+	if idx := strings.IndexAny(messageID, ";\t "); idx >= 0 {
+		messageID = messageID[:idx]
+	}
+
+	messageID = strings.TrimSpace(messageID)
+
+	return messageID
+}
+
+// messageExists checks if a message with the given Message-ID already exists in Gmail
+func (i *Importer) messageExists(messageID string) (bool, error) {
+	if messageID == "" {
+		return false, nil
+	}
+
+	// Search for message with this Message-ID
+	q := fmt.Sprintf("rfc822msgid:%s", messageID)
+
+	listCall := i.gmailService.Users.Messages.List("me").Q(q).MaxResults(1)
+	resp, err := listCall.Do()
+	if err != nil {
+		return false, fmt.Errorf("failed to check if message exists: %w", err)
+	}
+
+	// If we get any results, the message exists
+	return len(resp.Messages) > 0, nil
 }
 
 // encodeBase64URL encodes data in base64url format for Gmail API

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -26,6 +26,7 @@ type Config struct {
 	ParallelWorkers int    `json:"parallel_workers"`
 	PreserveDates   bool   `json:"preserve_dates"`
 	Limit           int    `json:"limit"`
+	Labels          string `json:"labels"`
 }
 
 // Result represents the import operation result
@@ -47,10 +48,14 @@ type Failure struct {
 
 // Importer handles email import operations
 type Importer struct {
-	config        *Config
-	authenticator *auth.Authenticator
-	gmailService  *gmail.Service
-	metrics       *metrics.Collector
+	config           *Config
+	authenticator    *auth.Authenticator
+	gmailService     *gmail.Service
+	metrics          *metrics.Collector
+	labelIds         []string
+	labelCache       map[string]string
+	labelCacheMutex  sync.RWMutex
+	allLabelsFetched bool
 }
 
 // New creates a new importer instance
@@ -100,6 +105,9 @@ func (i *Importer) Import() (*Result, error) {
 	}
 
 	logrus.WithField("count", len(emailFiles)).Info("Found email files to import")
+
+	// Initialize label cache
+	i.labelCache = make(map[string]string)
 
 	// Apply limit if specified
 	if i.config.Limit > 0 && len(emailFiles) > i.config.Limit {
@@ -273,9 +281,13 @@ func (i *Importer) importSingleEmail(filePath string) (int64, error) {
 
 // importEMLFile imports an EML format email
 func (i *Importer) importEMLFile(data []byte) (int64, error) {
+	// Extract labels from email headers
+	labelIds := i.getLabelIdsForEmail(data)
+
 	// Create a Gmail message from the EML data
 	message := &gmail.Message{
-		Raw: encodeBase64URL(data),
+		Raw:      encodeBase64URL(data),
+		LabelIds: labelIds,
 	}
 
 	// Import the message (does not send, just adds to mailbox)
@@ -298,13 +310,22 @@ func (i *Importer) importJSONFile(data []byte) (int64, error) {
 		return 0, fmt.Errorf("failed to parse JSON: %w", err)
 	}
 
+	// Extract labels from email headers
+	rawBytes, err := base64.URLEncoding.DecodeString(emailData.Raw + strings.Repeat("=", ((4-len(emailData.Raw)%4)%4)))
+	if err != nil {
+		// If decoding fails, just use the raw as-is
+		rawBytes = []byte(emailData.Raw)
+	}
+	labelIds := i.getLabelIdsForEmail(rawBytes)
+
 	// Create a Gmail message
 	message := &gmail.Message{
-		Raw: emailData.Raw,
+		Raw:      emailData.Raw,
+		LabelIds: labelIds,
 	}
 
 	// Import the message (does not send, just adds to mailbox)
-	_, err := i.gmailService.Users.Messages.Import("me", message).Do()
+	_, err = i.gmailService.Users.Messages.Import("me", message).Do()
 	if err != nil {
 		return 0, fmt.Errorf("failed to import message: %w", err)
 	}
@@ -317,7 +338,8 @@ func (i *Importer) importMboxFile(data []byte) (int64, error) {
 	// For mbox files, we need to parse the format and extract individual messages
 	// This is a simplified implementation - in practice, you'd want a proper mbox parser
 	message := &gmail.Message{
-		Raw: encodeBase64URL(data),
+		Raw:      encodeBase64URL(data),
+		LabelIds: i.getLabelIdsForEmail(data),
 	}
 
 	// Import the message (does not send, just adds to mailbox)
@@ -327,6 +349,179 @@ func (i *Importer) importMboxFile(data []byte) (int64, error) {
 	}
 
 	return int64(len(data)), nil
+}
+
+// getLabelIdsForEmail extracts labels from email headers and resolves them to IDs
+func (i *Importer) getLabelIdsForEmail(data []byte) []string {
+	// Check if --labels flag is set (command-line labels)
+	if i.config.Labels != "" {
+		logrus.WithField("labels", i.config.Labels).Debug("Using --labels flag")
+		// Use command-line labels (cached)
+		if len(i.labelIds) == 0 {
+			i.labelCacheMutex.Lock()
+			if len(i.labelIds) == 0 {
+				// Resolve labels from command line
+				labelNames := strings.Split(i.config.Labels, ",")
+				for _, name := range labelNames {
+					name = strings.TrimSpace(name)
+					if name == "" {
+						continue
+					}
+					if labelId := i.resolveLabelName(name); labelId != "" {
+						i.labelIds = append(i.labelIds, labelId)
+					}
+				}
+			}
+			i.labelCacheMutex.Unlock()
+		}
+		return i.labelIds
+	}
+
+	// Extract labels from X-Gmail-Labels header
+	emailLabels := i.extractLabelsFromHeaders(data)
+	if len(emailLabels) == 0 {
+		return nil
+	}
+
+	// Resolve label names to IDs
+	labelIds := make([]string, 0, len(emailLabels))
+	for _, labelName := range emailLabels {
+		labelName = strings.TrimSpace(labelName)
+		if labelName == "" {
+			continue
+		}
+		if labelId := i.resolveLabelName(labelName); labelId != "" {
+			labelIds = append(labelIds, labelId)
+		}
+	}
+
+	logrus.WithFields(logrus.Fields{"email_labels": emailLabels, "resolved_count": len(labelIds)}).Debug("Processed email labels")
+	return labelIds
+}
+
+// extractLabelsFromHeaders extracts label names from the X-Gmail-Labels header
+func (i *Importer) extractLabelsFromHeaders(data []byte) []string {
+	dataStr := string(data)
+
+	// Find the X-Gmail-Labels header
+	headerPrefix := "\nX-Gmail-Labels:"
+	idx := strings.Index(dataStr, headerPrefix)
+	if idx == -1 {
+		return nil
+	}
+
+	// Extract the header value (up to the next line that doesn't start with whitespace)
+	start := idx + len(headerPrefix)
+	end := len(dataStr)
+
+	// Find the end of the header value (next line that doesn't start with whitespace)
+	for i := start; i < len(dataStr); i++ {
+		if dataStr[i] == '\n' && (i+1 >= len(dataStr) || (dataStr[i+1] != ' ' && dataStr[i+1] != '\t' && dataStr[i+1] != '\r')) {
+			end = i
+			break
+		}
+	}
+
+	// Extract and parse the label list
+	labelValue := strings.TrimSpace(dataStr[start:end])
+	if labelValue == "" {
+		return nil
+	}
+
+	// Split by comma and trim whitespace
+	labels := strings.Split(labelValue, ",")
+	result := make([]string, 0, len(labels))
+	for _, label := range labels {
+		label = strings.TrimSpace(label)
+		if label != "" {
+			result = append(result, label)
+		}
+	}
+
+	return result
+}
+
+// normalizeLabelName normalizes label names from X-Gmail-Labels header to Gmail API format
+func (i *Importer) normalizeLabelName(labelName string) string {
+	// Common mappings from X-Gmail-Labels to Gmail API
+	mappings := map[string]string{
+		"Important":           "IMPORTANT",
+		"Starred":             "STARRED",
+		"Unread":              "UNREAD",
+		"Category Personal":   "CATEGORY_PERSONAL",
+		"Category Social":     "CATEGORY_SOCIAL",
+		"Category Updates":    "CATEGORY_UPDATES",
+		"Category Forums":     "CATEGORY_FORUMS",
+		"Category Promotions": "CATEGORY_PROMOTIONS",
+	}
+
+	// Check for known mappings
+	if mapped, ok := mappings[labelName]; ok {
+		return mapped
+	}
+
+	// Convert "Category XXX" to "CATEGORY_XXX"
+	if strings.HasPrefix(labelName, "Category ") {
+		category := strings.TrimPrefix(labelName, "Category ")
+		category = strings.ToUpper(strings.ReplaceAll(category, " ", "_"))
+		return "CATEGORY_" + category
+	}
+
+	// Try uppercase for system labels
+	upper := strings.ToUpper(labelName)
+	if upper == "IMPORTANT" || upper == "STARRED" || upper == "INBOX" ||
+		upper == "SENT" || upper == "DRAFT" || upper == "SPAM" ||
+		upper == "TRASH" || upper == "UNREAD" || upper == "CHAT" {
+		return upper
+	}
+
+	// Return as-is for user-defined labels
+	return labelName
+}
+
+// resolveLabelName resolves a single label name to its ID (with caching)
+func (i *Importer) resolveLabelName(labelName string) string {
+	// Normalize label name first
+	normalizedName := i.normalizeLabelName(labelName)
+
+	// Check cache first
+	i.labelCacheMutex.RLock()
+	if labelId, ok := i.labelCache[normalizedName]; ok {
+		i.labelCacheMutex.RUnlock()
+		return labelId
+	}
+	i.labelCacheMutex.RUnlock()
+
+	// Fetch all labels if not already done
+	if !i.allLabelsFetched {
+		i.labelCacheMutex.Lock()
+		if !i.allLabelsFetched {
+			labelsResp, err := i.gmailService.Users.Labels.List("me").Do()
+			if err != nil {
+				i.labelCacheMutex.Unlock()
+				logrus.WithError(err).WithField("label", labelName).Warn("Failed to fetch labels, skipping")
+				return ""
+			}
+			logrus.WithField("count", len(labelsResp.Labels)).Debug("Fetched labels from Gmail")
+			for _, label := range labelsResp.Labels {
+				i.labelCache[label.Name] = label.Id
+			}
+			i.allLabelsFetched = true
+		}
+		i.labelCacheMutex.Unlock()
+	}
+
+	// Check cache again after fetching
+	i.labelCacheMutex.RLock()
+	labelId, ok := i.labelCache[normalizedName]
+	i.labelCacheMutex.RUnlock()
+
+	if !ok {
+		logrus.WithField("label", labelName).Debug("Label not found, skipping")
+		return ""
+	}
+
+	return labelId
 }
 
 // validateConfig validates the importer configuration

--- a/internal/importer/importer_test.go
+++ b/internal/importer/importer_test.go
@@ -92,6 +92,51 @@ func TestValidateConfig(t *testing.T) {
 	}
 }
 
+func TestExtractMessageID(t *testing.T) {
+	importer := &Importer{}
+
+	tests := []struct {
+		name       string
+		emailData  []byte
+		expectedID string
+	}{
+		{
+			name:       "simple message-id",
+			emailData:  []byte("From: sender@example.com\nTo: recipient@example.com\nSubject: Test\nMessage-ID: <test@example.com>\n\nBody"),
+			expectedID: "test@example.com",
+		},
+		{
+			name:       "message-id with parameters",
+			emailData:  []byte("From: sender@example.com\nTo: recipient@example.com\nSubject: Test\nMessage-ID: <test@example.com; Mon, 05 Feb 2026 12:00:00 GMT>\n\nBody"),
+			expectedID: "test@example.com",
+		},
+		{
+			name:       "message-id with angle brackets and space",
+			emailData:  []byte("From: sender@example.com\nTo: recipient@example.com\nSubject: Test\nMessage-ID: <test@example.com> \n\nBody"),
+			expectedID: "test@example.com",
+		},
+		{
+			name:       "no message-id header",
+			emailData:  []byte("From: sender@example.com\nTo: recipient@example.com\nSubject: Test\n\nBody"),
+			expectedID: "",
+		},
+		{
+			name:       "lowercase message-id",
+			emailData:  []byte("From: sender@example.com\nTo: recipient@example.com\nSubject: Test\nmessage-id: <test@example.com>\n\nBody"),
+			expectedID: "test@example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := importer.extractMessageID(tt.emailData)
+			if result != tt.expectedID {
+				t.Errorf("extractMessageID() = %q, want %q", result, tt.expectedID)
+			}
+		})
+	}
+}
+
 func TestNormalizeLabelName(t *testing.T) {
 	importer := &Importer{}
 

--- a/internal/importer/importer_test.go
+++ b/internal/importer/importer_test.go
@@ -92,6 +92,136 @@ func TestValidateConfig(t *testing.T) {
 	}
 }
 
+func TestNormalizeLabelName(t *testing.T) {
+	importer := &Importer{}
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "system label Important",
+			input:    "Important",
+			expected: "IMPORTANT",
+		},
+		{
+			name:     "system label Starred",
+			input:    "Starred",
+			expected: "STARRED",
+		},
+		{
+			name:     "system label Unread",
+			input:    "Unread",
+			expected: "UNREAD",
+		},
+		{
+			name:     "Category Personal",
+			input:    "Category Personal",
+			expected: "CATEGORY_PERSONAL",
+		},
+		{
+			name:     "Category Social",
+			input:    "Category Social",
+			expected: "CATEGORY_SOCIAL",
+		},
+		{
+			name:     "Category Updates",
+			input:    "Category Updates",
+			expected: "CATEGORY_UPDATES",
+		},
+		{
+			name:     "Category Forums",
+			input:    "Category Forums",
+			expected: "CATEGORY_FORUMS",
+		},
+		{
+			name:     "user-defined label",
+			input:    "my-custom-label",
+			expected: "my-custom-label",
+		},
+		{
+			name:     "user label with spaces",
+			input:    "projects/my project",
+			expected: "projects/my project",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := importer.normalizeLabelName(tt.input)
+			if result != tt.expected {
+				t.Errorf("normalizeLabelName(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestExtractLabelsFromHeaders(t *testing.T) {
+	importer := &Importer{}
+
+	tests := []struct {
+		name           string
+		emailData      []byte
+		expectedLabels []string
+	}{
+		{
+			name:           "single label",
+			emailData:      []byte("From: sender@example.com\nTo: recipient@example.com\nSubject: Test\nX-Gmail-Labels: Important\n\nBody"),
+			expectedLabels: []string{"Important"},
+		},
+		{
+			name:           "multiple labels",
+			emailData:      []byte("From: sender@example.com\nTo: recipient@example.com\nSubject: Test\nX-Gmail-Labels: Important,Starred,Unread\n\nBody"),
+			expectedLabels: []string{"Important", "Starred", "Unread"},
+		},
+		{
+			name:           "labels with spaces",
+			emailData:      []byte("From: sender@example.com\nTo: recipient@example.com\nSubject: Test\nX-Gmail-Labels: Category Personal, Category Social\n\nBody"),
+			expectedLabels: []string{"Category Personal", "Category Social"},
+		},
+		{
+			name:           "labels with whitespace",
+			emailData:      []byte("From: sender@example.com\nTo: recipient@example.com\nSubject: Test\nX-Gmail-Labels:  Important  ,  Starred  \n\nBody"),
+			expectedLabels: []string{"Important", "Starred"},
+		},
+		{
+			name:           "no labels header",
+			emailData:      []byte("From: sender@example.com\nTo: recipient@example.com\nSubject: Test\n\nBody"),
+			expectedLabels: nil,
+		},
+		{
+			name:           "empty labels header",
+			emailData:      []byte("From: sender@example.com\nTo: recipient@example.com\nSubject: Test\nX-Gmail-Labels: \n\nBody"),
+			expectedLabels: nil,
+		},
+		{
+			name:           "user-defined labels",
+			emailData:      []byte("From: sender@example.com\nTo: recipient@example.com\nSubject: Test\nX-Gmail-Labels: my-label,projects/work\n\nBody"),
+			expectedLabels: []string{"my-label", "projects/work"},
+		},
+		{
+			name:           "mixed system and user labels",
+			emailData:      []byte("From: sender@example.com\nTo: recipient@example.com\nSubject: Test\nX-Gmail-Labels: Important,my-label,Category Personal\n\nBody"),
+			expectedLabels: []string{"Important", "my-label", "Category Personal"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := importer.extractLabelsFromHeaders(tt.emailData)
+			if len(result) != len(tt.expectedLabels) {
+				t.Errorf("Expected %d labels, got %d: %v vs %v", len(tt.expectedLabels), len(result), tt.expectedLabels, result)
+			}
+			for i, label := range tt.expectedLabels {
+				if i >= len(result) || result[i] != label {
+					t.Errorf("Label %d: expected %q, got %q", i, label, result)
+				}
+			}
+		})
+	}
+}
+
 func TestFindEmailFiles(t *testing.T) {
 	// Create temporary directory with test files
 	tempDir, err := os.MkdirTemp("", "importer_test")

--- a/split-mbox-emails.py
+++ b/split-mbox-emails.py
@@ -109,9 +109,9 @@ def split_mbox(mbox_path, output_dir, verbose=False, counter=None):
     return count, counter
 
 
-if __name__ == "__main__":
+def main():
     if len(sys.argv) < 2:
-        print(f"Usage: {sys.argv[0]} <mbox_file|pattern> [output_dir] [options]")
+        print(f"Usage: {sys.argv[0]} <mbox_file|pattern|dir> [output_dir] [options]")
         print("")
         print("Options:")
         print("  -v, --verbose    Enable verbose output")
@@ -119,7 +119,7 @@ if __name__ == "__main__":
         print("")
         print("Arguments:")
         print(
-            '  mbox_file|pattern  Path to .mbox file or glob pattern (e.g., "mboxes/*.mbox")'
+            '  mbox_file|pattern|dir  Path to .mbox file, glob pattern (e.g., "mboxes/*.mbox"), or directory'
         )
         print(
             "  output_dir         Directory to save split .eml files (default: 2-split-to-import)"
@@ -128,6 +128,7 @@ if __name__ == "__main__":
         print("Examples:")
         print("  Split single file:  ./split-mbox-emails.py emails.mbox")
         print('  Split multiple files: ./split-mbox-emails.py "mboxes/*.mbox"')
+        print("  Split directory:      ./split-mbox-emails.py 1-to-split/")
         print(
             "  Split and append:    ./split-mbox-emails.py new.mbox 2-split-to-import -v"
         )
@@ -137,7 +138,7 @@ if __name__ == "__main__":
         sys.exit(1)
 
     # Parse arguments
-    input_pattern = sys.argv[1]
+    input_path = sys.argv[1]
     output_dir = "2-split-to-import"
     verbose = False
     clear_dir = False
@@ -171,24 +172,37 @@ if __name__ == "__main__":
                 sys.exit(1)
         print("Counter reset to 1", file=sys.stderr)
 
-    # Find matching files (supports glob patterns)
-    if "*" in input_pattern or "?" in input_pattern or "[" in input_pattern:
-        mbox_files = sorted(glob.glob(input_pattern))
+    # Find matching files (supports glob patterns and directories)
+    mbox_files = []
+
+    if os.path.isdir(input_path):
+        # Directory: find all .mbox files
+        for f in os.listdir(input_path):
+            if f.endswith(".mbox"):
+                mbox_files.append(os.path.join(input_path, f))
+        mbox_files.sort()
+        # For directories, create subdirectories for each file
+        use_subdirs = True
+    elif "*" in input_path or "?" in input_path or "[" in input_path:
+        # Glob pattern
+        mbox_files = sorted(glob.glob(input_path))
         if not mbox_files:
             print(
-                f"Error: No files found matching pattern: {input_pattern}",
+                f"Error: No files found matching pattern: {input_path}",
                 file=sys.stderr,
             )
             sys.exit(1)
+        use_subdirs = False
     else:
         # Single file - check if it exists
-        if not os.path.exists(input_pattern):
-            print(f"Error: File not found: {input_pattern}")
+        if not os.path.exists(input_path):
+            print(f"Error: File not found: {input_path}")
             sys.exit(1)
-        if not os.path.isfile(input_pattern):
-            print(f"Error: {input_pattern} is not a file")
+        if not os.path.isfile(input_path):
+            print(f"Error: {input_path} is not a file")
             sys.exit(1)
-        mbox_files = [input_pattern]
+        mbox_files = [input_path]
+        use_subdirs = False
 
     # Check if they are valid mbox files
     for mbox_file in mbox_files:
@@ -199,7 +213,7 @@ if __name__ == "__main__":
             )
             print("Proceeding anyway...", file=sys.stderr)
 
-    # Split all mbox files with a shared counter
+    # Split all mbox files
     counter = 1
     total_messages = 0
 
@@ -208,7 +222,14 @@ if __name__ == "__main__":
             print(f"\n{'=' * 50}", file=sys.stderr)
             print(f"Processing: {mbox_file}", file=sys.stderr)
 
-        count, counter = split_mbox(mbox_file, output_dir, verbose, counter)
+        # Determine output directory for this file
+        if use_subdirs:
+            base_name = os.path.splitext(os.path.basename(mbox_file))[0]
+            file_output_dir = os.path.join(output_dir, base_name)
+        else:
+            file_output_dir = output_dir
+
+        count, counter = split_mbox(mbox_file, file_output_dir, verbose, counter)
         total_messages += count
 
     print(
@@ -219,45 +240,6 @@ if __name__ == "__main__":
         print(f"Error: No valid emails found", file=sys.stderr)
         sys.exit(1)
 
-    # Parse arguments
-    mbox_path = sys.argv[1]
-    output_dir = "2-split-to-import"
-    verbose = False
 
-    i = 2
-    while i < len(sys.argv):
-        arg = sys.argv[i]
-
-        if arg in ["-v", "--verbose"]:
-            verbose = True
-            i += 1
-        elif not arg.startswith("-"):
-            output_dir = arg
-            i += 1
-        else:
-            print(f"Error: Unknown argument: {arg}", file=sys.stderr)
-            sys.exit(1)
-
-    # Validate input file
-    if not os.path.exists(mbox_path):
-        print(f"Error: File not found: {mbox_path}")
-        sys.exit(1)
-
-    if not os.path.isfile(mbox_path):
-        print(f"Error: {mbox_path} is not a file")
-        sys.exit(1)
-
-    # Check if it's a valid mbox file
-    if not is_valid_mbox(mbox_path):
-        print(
-            f"Warning: {mbox_path} does not appear to be a valid mbox file",
-            file=sys.stderr,
-        )
-        print("Proceeding anyway...", file=sys.stderr)
-
-    # Split the mbox file
-    count = split_mbox(mbox_path, output_dir, verbose)
-
-    if count == 0:
-        print(f"Error: No valid emails found in {mbox_path}", file=sys.stderr)
-        sys.exit(1)
+if __name__ == "__main__":
+    main()

--- a/split-mbox-emails.py
+++ b/split-mbox-emails.py
@@ -2,6 +2,8 @@
 import os
 import re
 import sys
+import glob
+import shutil
 from pathlib import Path
 
 
@@ -18,16 +20,17 @@ def is_valid_mbox(file_path):
         return True
 
 
-def split_mbox(mbox_path, output_dir, verbose=False):
+def split_mbox(mbox_path, output_dir, verbose=False, counter=None):
     """Split an mbox file into individual .eml files
 
     Args:
         mbox_path: Path to the .mbox file
         output_dir: Directory to save split .eml files
         verbose: Enable verbose output for debugging
+        counter: Starting message number (for processing multiple files)
 
     Returns:
-        int: Number of messages split and saved
+        tuple: (int messages saved, int new counter value)
     """
 
     # Create output directory if it doesn't exist
@@ -46,6 +49,10 @@ def split_mbox(mbox_path, output_dir, verbose=False):
     count = 0
     skipped = 0
     empty = 0
+
+    # Use provided counter or start at 1
+    if counter is None:
+        counter = 1
 
     for i, msg in enumerate(messages):
         msg = msg.strip()
@@ -81,12 +88,13 @@ def split_mbox(mbox_path, output_dir, verbose=False):
                 print(f"  Message {i}: Empty after trimming, skipping", file=sys.stderr)
             continue
 
-        # Save to file
-        output_path = os.path.join(output_dir, f"msg.{i:03d}.eml")
+        # Save to file (use global counter)
+        output_path = os.path.join(output_dir, f"msg.{counter:03d}.eml")
         try:
             with open(output_path, "w", encoding="utf-8") as out:
                 out.write(msg)
             count += 1
+            counter += 1
             if verbose and count % 10 == 0:
                 print(f"  Processed {count} messages...", file=sys.stderr)
         except Exception as e:
@@ -98,21 +106,117 @@ def split_mbox(mbox_path, output_dir, verbose=False):
         print(f"  Skipped {skipped} empty/invalid messages", file=sys.stderr)
     if empty > 0:
         print(f"  Found {empty} empty messages", file=sys.stderr)
-    return count
+    return count, counter
 
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
-        print(f"Usage: {sys.argv[0]} <mbox_file> [output_dir] [options]")
+        print(f"Usage: {sys.argv[0]} <mbox_file|pattern> [output_dir] [options]")
         print("")
         print("Options:")
         print("  -v, --verbose    Enable verbose output")
+        print("  -c, --clear      Clear output directory and reset counter")
         print("")
         print("Arguments:")
-        print("  mbox_file     Path to the .mbox file to split")
         print(
-            "  output_dir     Directory to save split .eml files (default: 2-split-to-import)"
+            '  mbox_file|pattern  Path to .mbox file or glob pattern (e.g., "mboxes/*.mbox")'
         )
+        print(
+            "  output_dir         Directory to save split .eml files (default: 2-split-to-import)"
+        )
+        print("")
+        print("Examples:")
+        print("  Split single file:  ./split-mbox-emails.py emails.mbox")
+        print('  Split multiple files: ./split-mbox-emails.py "mboxes/*.mbox"')
+        print(
+            "  Split and append:    ./split-mbox-emails.py new.mbox 2-split-to-import -v"
+        )
+        print(
+            "  Clear and restart:   ./split-mbox-emails.py *.mbox 2-split-to-import --clear"
+        )
+        sys.exit(1)
+
+    # Parse arguments
+    input_pattern = sys.argv[1]
+    output_dir = "2-split-to-import"
+    verbose = False
+    clear_dir = False
+
+    i = 2
+    while i < len(sys.argv):
+        arg = sys.argv[i]
+
+        if arg in ["-v", "--verbose"]:
+            verbose = True
+            i += 1
+        elif arg in ["-c", "--clear"]:
+            clear_dir = True
+            i += 1
+        elif not arg.startswith("-"):
+            output_dir = arg
+            i += 1
+        else:
+            print(f"Error: Unknown argument: {arg}", file=sys.stderr)
+            sys.exit(1)
+
+    # Clear output directory if requested
+    if clear_dir:
+        if os.path.exists(output_dir):
+            print(f"Clearing output directory: {output_dir}", file=sys.stderr)
+            try:
+                shutil.rmtree(output_dir)
+                os.makedirs(output_dir, exist_ok=True)
+            except Exception as e:
+                print(f"Error clearing directory: {e}", file=sys.stderr)
+                sys.exit(1)
+        print("Counter reset to 1", file=sys.stderr)
+
+    # Find matching files (supports glob patterns)
+    if "*" in input_pattern or "?" in input_pattern or "[" in input_pattern:
+        mbox_files = sorted(glob.glob(input_pattern))
+        if not mbox_files:
+            print(
+                f"Error: No files found matching pattern: {input_pattern}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+    else:
+        # Single file - check if it exists
+        if not os.path.exists(input_pattern):
+            print(f"Error: File not found: {input_pattern}")
+            sys.exit(1)
+        if not os.path.isfile(input_pattern):
+            print(f"Error: {input_pattern} is not a file")
+            sys.exit(1)
+        mbox_files = [input_pattern]
+
+    # Check if they are valid mbox files
+    for mbox_file in mbox_files:
+        if not is_valid_mbox(mbox_file):
+            print(
+                f"Warning: {mbox_file} does not appear to be a valid mbox file",
+                file=sys.stderr,
+            )
+            print("Proceeding anyway...", file=sys.stderr)
+
+    # Split all mbox files with a shared counter
+    counter = 1
+    total_messages = 0
+
+    for mbox_file in mbox_files:
+        if verbose:
+            print(f"\n{'=' * 50}", file=sys.stderr)
+            print(f"Processing: {mbox_file}", file=sys.stderr)
+
+        count, counter = split_mbox(mbox_file, output_dir, verbose, counter)
+        total_messages += count
+
+    print(
+        f"\n✓ Total: {total_messages} messages split to {output_dir}/", file=sys.stderr
+    )
+
+    if total_messages == 0:
+        print(f"Error: No valid emails found", file=sys.stderr)
         sys.exit(1)
 
     # Parse arguments

--- a/split-mbox-emails.py
+++ b/split-mbox-emails.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+import os
+import re
+import sys
+from pathlib import Path
+
+
+def is_valid_mbox(file_path):
+    """Check if file appears to be a valid mbox file"""
+    try:
+        with open(file_path, "r", encoding="utf-8", errors="ignore") as f:
+            first_chunk = f.read(1000)
+
+        # Check for common mbox patterns
+        return "From " in first_chunk and ("\nFrom " in first_chunk[:2000])
+    except Exception as e:
+        print(f"Warning: Could not validate file: {e}", file=sys.stderr)
+        return True
+
+
+def split_mbox(mbox_path, output_dir, verbose=False):
+    """Split an mbox file into individual .eml files
+
+    Args:
+        mbox_path: Path to the .mbox file
+        output_dir: Directory to save split .eml files
+        verbose: Enable verbose output for debugging
+
+    Returns:
+        int: Number of messages split and saved
+    """
+
+    # Create output directory if it doesn't exist
+    os.makedirs(output_dir, exist_ok=True)
+
+    if verbose:
+        print(f"Reading mbox file: {mbox_path}", file=sys.stderr)
+        print(f"Output directory: {output_dir}", file=sys.stderr)
+
+    with open(mbox_path, "r", encoding="utf-8", errors="ignore") as f:
+        content = f.read()
+
+    # Split by "From " lines (mbox format)
+    messages = re.split(r"\nFrom ", content)
+
+    count = 0
+    skipped = 0
+    empty = 0
+
+    for i, msg in enumerate(messages):
+        msg = msg.strip()
+        if not msg:
+            empty += 1
+            if verbose:
+                print(f"  Message {i}: Empty, skipping", file=sys.stderr)
+            continue
+
+        # Skip the first message if it's empty (from the split)
+        if i == 0 and not msg.startswith("<!DOCTYPE"):
+            if verbose:
+                print(
+                    f"  Message {i}: First message empty (no DOCTYPE), skipping",
+                    file=sys.stderr,
+                )
+            skipped += 1
+            continue
+
+        # Re-add the "From " line (minus the first one)
+        if i > 0:
+            msg = "From " + msg
+
+        # Remove the first "From " line content to get the actual email
+        lines = msg.split("\n", 1)
+        if len(lines) > 1 and lines[0].startswith("From "):
+            msg = lines[1]
+
+        # Skip empty messages after trimming
+        if not msg.strip():
+            empty += 1
+            if verbose:
+                print(f"  Message {i}: Empty after trimming, skipping", file=sys.stderr)
+            continue
+
+        # Save to file
+        output_path = os.path.join(output_dir, f"msg.{i:03d}.eml")
+        try:
+            with open(output_path, "w", encoding="utf-8") as out:
+                out.write(msg)
+            count += 1
+            if verbose and count % 10 == 0:
+                print(f"  Processed {count} messages...", file=sys.stderr)
+        except Exception as e:
+            print(f"Error writing message {i}: {e}", file=sys.stderr)
+            continue
+
+    print(f"✓ Split {count} messages to {output_dir}/")
+    if skipped > 0:
+        print(f"  Skipped {skipped} empty/invalid messages", file=sys.stderr)
+    if empty > 0:
+        print(f"  Found {empty} empty messages", file=sys.stderr)
+    return count
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <mbox_file> [output_dir] [options]")
+        print("")
+        print("Options:")
+        print("  -v, --verbose    Enable verbose output")
+        print("")
+        print("Arguments:")
+        print("  mbox_file     Path to the .mbox file to split")
+        print(
+            "  output_dir     Directory to save split .eml files (default: 2-split-to-import)"
+        )
+        sys.exit(1)
+
+    # Parse arguments
+    mbox_path = sys.argv[1]
+    output_dir = "2-split-to-import"
+    verbose = False
+
+    i = 2
+    while i < len(sys.argv):
+        arg = sys.argv[i]
+
+        if arg in ["-v", "--verbose"]:
+            verbose = True
+            i += 1
+        elif not arg.startswith("-"):
+            output_dir = arg
+            i += 1
+        else:
+            print(f"Error: Unknown argument: {arg}", file=sys.stderr)
+            sys.exit(1)
+
+    # Validate input file
+    if not os.path.exists(mbox_path):
+        print(f"Error: File not found: {mbox_path}")
+        sys.exit(1)
+
+    if not os.path.isfile(mbox_path):
+        print(f"Error: {mbox_path} is not a file")
+        sys.exit(1)
+
+    # Check if it's a valid mbox file
+    if not is_valid_mbox(mbox_path):
+        print(
+            f"Warning: {mbox_path} does not appear to be a valid mbox file",
+            file=sys.stderr,
+        )
+        print("Proceeding anyway...", file=sys.stderr)
+
+    # Split the mbox file
+    count = split_mbox(mbox_path, output_dir, verbose)
+
+    if count == 0:
+        print(f"Error: No valid emails found in {mbox_path}", file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
## Summary

Enhanced `split-mbox-emails.py` helper script with support for processing multiple files from glob patterns and directories. Updated README to explain that `.mbox` files must be split into individual `.eml` files before importing with `gmail-exporter import`.

## Problem

Users were confused when importing `.mbox` files because the importer would only import one message from the entire file, rather than processing each individual email contained within the mbox format.

## Solution

### 1. Enhanced split-mbox-emails.py script:

**Validation & Error Handling:**
- Added `is_valid_mbox()` validation to check if file is valid mbox format
- Added verbose mode (`-v` or `--verbose`) for debugging
- Improved error handling and user feedback
- Tracks empty/invalid messages separately
- Better progress reporting (every 10 messages)
- Proper UTF-8 encoding support

**Multi-file Processing:**
- Support for glob patterns to process multiple mbox files at once (e.g., `"mboxes/*.mbox"`)
- Added `--clear`/`-c` flag to reset output directory and counter
- Use shared counter across all files to avoid clobbering
- **NEW:** Support for directory input - processes all `.mbox` files in a directory
- **NEW:** Create separate subdirectories for each file when using directory input
- Better usage examples showing glob patterns and directories

### 2. Updated README.md:
- Added warning in Mbox Format section about splitting requirement
- Added complete mbox import workflow with split command
- Added all import options for mbox files (labels, deduplication, etc.)
- Documented `split-mbox-emails.py` in Features and Tools sections
- Added cross-account migration example with mbox files

### 3. Enhanced importer with deduplication and labels:
- Add deduplication support via `--skip-duplicates` flag
- Extract and apply labels from `X-Gmail-Labels` header during import via `--labels` flag
- Support for preserving Gmail's native labels when migrating emails

## Changes

### split-mbox-emails.py
- Added `is_valid_mbox()` validation function
- Added verbose mode with `-v` or `--verbose` flags
- Added `--clear`/`-c` flag to reset output directory and counter
- Added glob pattern support for processing multiple files
- Added directory input support with automatic subdirectory creation
- Improved error handling and feedback messages
- Added UTF-8 encoding support
- Tracks empty and invalid message counts separately
- Better progress feedback (every 10 messages)
- Better argument parsing for options

### README.md
- **Mbox Format section**: Added warning about splitting requirement with example workflow
- **Features section**: Added mention of `split-mbox-emails.py` helper tool
- **Cross-Account Migration section**: Added complete mbox import workflow example
- **Tools section**: Added documentation for both `gmail-exporter` and `split-mbox-emails.py`

### internal/cli/import.go & internal/importer/importer.go
- Added `--skip-duplicates` flag to skip emails already in Gmail
- Added `--labels` flag to extract and apply X-Gmail-Labels header values
- Enhanced error handling and progress reporting during import

## Usage

### Splitting mbox files:
```bash
# Split single mbox file (with verbose output)
./split-mbox-emails.py -v backups/my_emails.mbox backups/split

# Split multiple mbox files using glob pattern
./split-mbox-emails.py "backups/*.mbox" backups/split

# Split all mbox files from a directory (creates subdirectories)
./split-mbox-emails.py 1-to-split/ 2-split-to-import

# Clear output and restart with counter reset
./split-mbox-emails.py "backups/*.mbox" backups/split --clear
```

### Importing split emails:
```bash
# Import split emails
./gmail-exporter import --input-dir backups/split

# Import with labels from X-Gmail-Labels header
./gmail-exporter import --input-dir backups/split --labels

# Import with deduplication
./gmail-exporter import --input-dir backups/split --skip-duplicates
```

### Complete workflow:
```bash
# 1. Export from source account
./gmail-exporter export --output-dir migration --format eml

# 2. Split mbox files from directory
./split-mbox-emails.py migration/ 2-split-to-import

# 3. Test import (first 5 emails, with labels)
./gmail-exporter import --input-dir 2-split-to-import --limit 5 --labels --skip-duplicates

# 4. Full import (if test successful)
./gmail-exporter import --input-dir 2-split-to-import --labels --skip-duplicates
```

## Benefits

- **Better user experience**: Clear guidance on how to import mbox files
- **Robust mbox handling**: Validates format before processing
- **Flexible input options**: Support files, glob patterns, and directories
- **Debugging support**: Verbose mode for troubleshooting
- **Error visibility**: Separate counts for empty/invalid messages
- **Label preservation**: Extract and apply Gmail labels during import
- **Deduplication**: Skip emails that already exist in Gmail
- **Complete documentation**: Covers both tool and workflow

This change prevents confusion about importing `.mbox` files and provides
a robust helper script for the task with flexible input options.