### PR TITLE
feat: Add --no-inbox flag to exclude Inbox label from imports

### DIFF
--- a/BATCH_IMPORT_GUIDE.md
+++ b/BATCH_IMPORT_GUIDE.md
@@ -1,0 +1,38 @@
+# Gmail Batch Import - Quick Start Guide
+
+## What you need:
+
+1. ✅ Google Takeout extracted to `/Volumes/Samsung 2T/GoogleTakeout_2025-11/Mail/`
+2. ✅ Labels created in Gmail: `import-inbox-YYYY-MM-DD`, `import-sent-YYYY-MM-DD`, etc.
+3. ✅ Gmail authenticated: `./gmail-exporter auth`
+4. ✅ Files ready: `import-all.sh`, `split-mbox-emails-streaming.py`, `gmail-exporter`
+
+## Quick Start:
+
+```bash
+# Run the batch import script
+./import-all.sh
+```
+
+## What happens:
+
+1. 📧 **Inbox.mbox** → Imported with label `import-inbox-$(date +%Y-%m-%d)`
+2. 📤 **Sent.mbox** → Imported with label `import-sent-$(date +%Y-%m-%d)`
+3. ⭐ **Starred.mbox** → Imported with label `import-starred-$(date +%Y-%m-%d)`
+4. 📦 **Archived.mbox** → Imported with label `import-archived-$(date +%Y-%m-%d)`
+
+## After import:
+
+1. 📖 Open Gmail
+2. 🔍 Search for: `import-2026-02-05` (or whatever today's date is)
+3. ✅ Verify all imported emails appear with their labels
+4. 🗑️ Delete the `import-YYYY-MM-DD` labels when done (optional)
+
+## Need to import again tomorrow?
+
+Just run `./import-all.sh` again - it will use tomorrow's date automatically!
+
+## Questions?
+
+- See `IMPORT_ALL_README.md` for detailed documentation
+- See `IMPORT_FLAGS.txt` for flag reference

--- a/IMPORT_ALL_README.md
+++ b/IMPORT_ALL_README.md
@@ -1,0 +1,126 @@
+# Gmail Import Batch Script
+
+This script automates importing all main Gmail folders from Google Takeout.
+
+## What it does
+
+Imports these 4 mbox files in sequence:
+1. **Inbox.mbox** - Received emails (with label `import-inbox-DATE`)
+2. **Sent.mbox** - Sent emails (with label `import-sent-DATE`)
+3. **Starred.mbox** - Starred emails (with label `import-starred-DATE`)
+4. **Archived.mbox** - Archived emails (with label `import-archived-DATE`)
+
+## Why these 4 files?
+
+Google Takeout creates multiple mbox files:
+- **Inbox.mbox** - All received emails (~8.1G)
+- **Sent.mbox** - All sent emails (~16G)
+- **Starred.mbox** - All starred emails (~2.5G)
+- **Archived.mbox** - All archived emails (~19G)
+- Category files (Personal, Social, etc.) - **Subsets of Inbox**
+
+**Category files are skipped** because they contain duplicate emails from Inbox.mbox.
+If you imported both, you'd have duplicate emails in Gmail.
+
+## Prerequisites
+
+1. Google Takeout extracted to `/Volumes/Samsung 2T/GoogleTakeout_2025-11/Mail/`
+2. `split-mbox-emails-streaming.py` script in current directory (streaming version for large files)
+3. `gmail-exporter` binary built and in current directory
+4. Gmail authentication configured (run `./gmail-exporter auth` first)
+5. Import labels created in Gmail: `import-inbox-YYYY-MM-DD`, etc.
+
+## Usage
+
+### Step 1: Update configuration (optional)
+
+Edit `import-all.sh` to change:
+- `MAIL_DIR` - Path to your Google Takeout Mail directory
+- `IMPORT_DATE` - Date stamp for import labels (auto-generated as YYYY-MM-DD)
+
+### Step 2: Run the script
+
+```bash
+./import-all.sh
+```
+
+### Step 3: Verify in Gmail
+
+1. Open Gmail
+2. Search for: `import-YYYY-MM-DD` (e.g., import-2026-02-05)
+3. You should see all imported emails with labels:
+   - `import-inbox-YYYY-MM-DD`
+   - `import-sent-YYYY-MM-DD`
+   - `import-starred-YYYY-MM-DD`
+   - `import-archived-YYYY-MM-DD`
+
+## What happens during import
+
+### Inbox.mbox
+- Split to individual .eml files
+- Import with `--skip-duplicates --skip-categories --no-inbox --no-starred --no-important`
+- Add label `import-inbox-YYYY-MM-DD` (auto-generated date)
+- Result: Imported to Gmail without Inbox/Starred/Important flags
+
+### Sent.mbox
+- Split to individual .eml files
+- Import with `--skip-duplicates --skip-categories --no-inbox`
+- Add label `import-sent-YYYY-MM-DD` (auto-generated date)
+- Result: Imported to Gmail with SENT label (appears in Sent folder)
+
+### Starred.mbox
+- Split to individual .eml files
+- Import with `--skip-duplicates --skip-categories --no-inbox --no-starred`
+- Add label `import-starred-YYYY-MM-DD` (auto-generated date)
+- Result: Imported to Gmail with Starred label
+
+### Archived.mbox
+- Split to individual .eml files
+- Import with `--skip-duplicates --skip-categories --no-inbox`
+- Add label `import-archived-YYYY-MM-DD` (auto-generated date)
+- Result: Imported to Gmail
+
+## Flags explained
+
+| Flag | Purpose | When used |
+|-------|----------|-----------|
+| `--skip-duplicates` | Skip emails already in Gmail | Always |
+| `--skip-categories` | Skip Gmail category labels | Always (categories are system-managed) |
+| `--no-inbox` | Don't add Inbox label | All except Inbox |
+| `--no-starred` | Don't add Starred label | Inbox, Starred |
+| `--no-important` | Don't add Important label | Inbox only |
+
+## Troubleshooting
+
+### Script fails with "File not found"
+- Update `MAIL_DIR` in script to correct path
+- Check that Google Takeout is extracted
+
+### Import fails with authentication error
+- Run `./gmail-exporter auth` first
+- Check that credentials file exists
+
+### Duplicate emails appear in Gmail
+- Make sure `--skip-duplicates` is used (it is by default)
+- Check that Message-ID headers are consistent
+
+### Some emails missing in Gmail
+- Check logs for errors
+- Verify `import-DATE` labels are being applied
+- Use `--limit 10` to test with a small batch first
+
+## Importing specific files only
+
+If you want to import just one folder:
+
+```bash
+# Import only Inbox
+./split-mbox-emails.py '/Volumes/Samsung 2T/GoogleTakeout_2025-11/Mail/Inbox.mbox' --clear
+./gmail-exporter import --skip-duplicates --no-inbox --no-starred --no-important --skip-categories \
+  --input-dir 2-split-to-import --add-label="import-inbox-$(date +%Y-%m-%d)"
+
+# Import only Sent
+./split-mbox-emails.py '/Volumes/Samsung 2T/GoogleTakeout_2025-11/Mail/Sent.mbox' --clear
+./gmail-exporter import --skip-duplicates --skip-categories \
+  --input-dir 2-split-to-import --add-label="import-sent-$(date +%Y-%m-%d)"
+```

--- a/IMPORT_FLAGS.txt
+++ b/IMPORT_FLAGS.txt
@@ -1,0 +1,114 @@
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                  Gmail Import Flags Quick Reference                  │
+└─────────────────────────────────────────────────────────────────────────────┘
+
+┌─ Basic Flags ─────────────────────────────────────────────────────────┐
+│                                                              │
+│  --skip-duplicates    Skip emails already in Gmail (always use)    │
+│  --skip-categories    Skip Gmail category labels (always use)      │
+│                                                              │
+└───────────────────────────────────────────────────────────────────────┘
+
+┌─ Inbox Messages ─────────────────────────────────────────────────────┐
+│                                                              │
+│  --no-inbox          Don't add Inbox label               │
+│  --no-starred        Don't add Starred label             │
+│  --no-important      Don't add Important label           │
+│                                                              │
+│  Example:                                                    │
+│  ./gmail-exporter import --skip-duplicates --no-inbox \       │
+│    --no-starred --no-important --skip-categories \             │
+│    --input-dir 2-split-to-import --add-label="import-2026-02-05"│
+│                                                              │
+└───────────────────────────────────────────────────────────────────────┘
+
+┌─ Sent Messages ──────────────────────────────────────────────────────┐
+│                                                              │
+│  --no-inbox          Don't add to Inbox (they go to Sent)   │
+│                                                              │
+│  Example:                                                    │
+│  ./gmail-exporter import --skip-duplicates --no-inbox \       │
+│    --skip-categories \                                     │
+│    --input-dir 2-split-to-import --add-label="import-sent-2026-02-05"│
+│                                                              │
+└───────────────────────────────────────────────────────────────────────┘
+
+┌─ Starred Messages ────────────────────────────────────────────────────┐
+│                                                              │
+│  --no-inbox          Don't add to Inbox                   │
+│  --no-starred        Don't add Starred label (they're already)   │
+│                                                              │
+│  Example:                                                    │
+│  ./gmail-exporter import --skip-duplicates --no-inbox \       │
+│    --no-starred --skip-categories \                        │
+│    --input-dir 2-split-to-import --add-label="import-starred-2026-02-05"│
+│                                                              │
+└───────────────────────────────────────────────────────────────────────┘
+
+┌─ Archived Messages ───────────────────────────────────────────────────┐
+│                                                              │
+│  --no-inbox          Don't add to Inbox                │
+│                                                              │
+│  Example:                                                    │
+│  ./gmail-exporter import --skip-duplicates --no-inbox \       │
+│    --skip-categories \                                     │
+│    --input-dir 2-split-to-import --add-label="import-archived-2026-02-05"│
+│                                                              │
+└───────────────────────────────────────────────────────────────────────┘
+
+┌─ Category Labels (Personal, Social, Purchases, etc.) ────────────┐
+│                                                              │
+│  Gmail categories are SYSTEM-MANAGED and cannot be set via API      │
+│  They are automatically assigned by Gmail based on:                 │
+│    • Email content analysis                                     │
+│    • Sender reputation/patterns                                 │
+│    • Subject line patterns                                      │
+│                                                              │
+│  Always use --skip-categories to:                              │
+│    • Avoid warnings                                            │
+│    • Prevent API errors                                          │
+│    • Keep logs clean                                           │
+│                                                              │
+│  Note: Messages will still get categorized after import!              │
+│        Gmail's classifiers analyze them within minutes/hours.           │
+│                                                              │
+└───────────────────────────────────────────────────────────────────────┘
+
+┌─ Label to Identify Imports ────────────────────────────────────────────┐
+│                                                              │
+│  --add-label="import-YYYY-MM-DD"                              │
+│                                                              │
+│  This label is added to ALL imported emails, making them:              │
+│    • Easy to find (search for import-YYYY-MM-DD)             │
+│    • Easy to filter (create filter for import-YYYY-MM-DD)       │
+│    • Easy to manage (archive/delete after verification)             │
+│                                                              │
+│  Requirements:                                                │
+│    • Label must exist in Gmail FIRST                             │
+│    • Create manually in Gmail web interface or via API                │
+│                                                              │
+│  Note: In batch script, date is auto-generated!                   │
+│                                                              │
+└───────────────────────────────────────────────────────────────────────┘
+
+┌─ Batch Import Script ──────────────────────────────────────────────────┐
+│                                                              │
+│  ./import-all.sh                                            │
+│                                                              │
+│  Automates importing all 4 main files:                          │
+│    1. Inbox.mbox    → import-inbox-YYYY-MM-DD              │
+│    2. Sent.mbox      → import-sent-YYYY-MM-DD                   │
+│    3. Starred.mbox   → import-starred-YYYY-MM-DD                │
+│    4. Archived.mbox  → import-archived-YYYY-MM-DD             │
+│                                                              │
+│  Features:                                                    │
+│    • Clear output directory between imports                      │
+│    • Colored progress output                                    │
+│    • Error handling                                             │
+│    • Auto-generates current date (YYYY-MM-DD)                    │
+│                                                              │
+│  Edit script to customize:                                       │
+│    • MAIL_DIR - Path to Google Takeout                          │
+│    • IMPORT_DATE - Date stamp for labels (auto: YYYY-MM-DD)     │
+│                                                              │
+└───────────────────────────────────────────────────────────────────────┘

--- a/README.md
+++ b/README.md
@@ -6,13 +6,16 @@ A powerful command-line tool for exporting, importing, and managing Gmail emails
 
 - **Export emails** from Gmail with advanced filtering (supports all Gmail search operators)
 - **Import emails** into Gmail accounts (supports cross-account transfers)
-- **Cleanup emails** from source account after export
+- **Preserve labels** from original emails (via X-Gmail-Labels header)
+- **Avoid duplicates** during import with Message-ID checking
+- **Cleanup emails** from source account after migration (archive or delete)
 - **Multiple formats**: EML, JSON, mbox
 - **Parallel processing** for high performance
 - **Progress tracking** with real-time indicators
 - **Resumable operations** with state management
-- **Comprehensive metrics** collection (JSON and Prometheus formats)
+- **Comprehensive metrics** collection (JSON and Prometheus)
 - **OAuth 2.0 authentication** with Google Gmail API
+- **Mbox helper script** (`split-mbox-emails.py`) to split mbox files for importing
 - **Cross-account support** for migrating between Gmail accounts
 
 ## Installation
@@ -124,27 +127,53 @@ For migrating emails between different Gmail accounts:
 
 ### Cross-Account Migration
 
+For migrating emails between different Gmail accounts:
+
 ```bash
 # 1. Export from source account
 ./gmail-exporter export \
   --credentials-file source-creds.json \
   --token-file source-token.json \
-  --output-dir migration/ \
-  --search-scope "all_mail"
+  --output-dir migration-exports \
+  --format eml
 
 # 2. Import to destination account
 ./gmail-exporter import \
-  --input-dir migration/ \
+  --input-dir migration-exports \
   --import-credentials dest-creds.json \
   --import-token dest-token.json
+```
 
-# 3. Optional: Clean up source account
-# Note: The export process automatically creates processed_emails.json
-./gmail-exporter cleanup \
-  --credentials-file source-creds.json \
-  --token-file source-token.json \
-  --action archive \
-  --filter-file migration/processed_emails.json
+### Import Mbox Files
+
+When importing mbox files, first split them into individual emails:
+
+```bash
+# Split mbox into individual .eml files
+./split-mbox-emails.py backups/my_emails.mbox backups/split
+
+# Import the split emails
+./gmail-exporter import --input-dir backups/split
+```
+
+**Mbox Import Options:**
+
+```bash
+# Import with label preservation (emails with X-Gmail-Labels header)
+./split-mbox-emails.py backups/my_emails.mbox backups/split
+./gmail-exporter import --input-dir backups/split
+
+# Import with custom labels (overrides email labels)
+./split-mbox-emails.py backups/my_emails.mbox backups/split
+./gmail-exporter import --input-dir backups/split --labels "tickets,work"
+
+# Import with deduplication (skip emails already in Gmail)
+./split-mbox-emails.py backups/my_emails.mbox backups/split
+./gmail-exporter import --input-dir backups/split --skip-duplicates
+
+# Test import with limit first
+./split-mbox-emails.py backups/my_emails.mbox backups/split
+./gmail-exporter import --input-dir backups/split --limit 5
 ```
 
 ### Generate Filter File from Existing Exports
@@ -224,19 +253,28 @@ All Gmail search operators are supported:
 - `--labels`: Specific labels (comma-separated)
 - `--search-scope`: Search scope (all_mail, inbox, sent, drafts, spam, trash)
 
-## Output Formats
+### Output Formats
 
 ### EML Format (Default)
-
 Standard email format that preserves all email data including headers, body, and attachments.
 
 ### JSON Format
-
-Structured format containing the complete Gmail API message object.
+Structured format containing the complete Gmail API message object, useful for programmatic processing.
 
 ### Mbox Format
+Unix mailbox format for compatibility with email clients. Contains multiple emails in a single file.
 
-Unix mailbox format for compatibility with email clients.
+**⚠️ Important:** Mbox files must be split into individual .eml files before importing. Use the provided `split-mbox-emails.py` helper script:
+
+```bash
+# Split mbox file into individual emails
+./split-mbox-emails.py exports/my_emails.mbox exports/split
+
+# Now import the individual emails
+./gmail-exporter import --input-dir exports/split
+```
+
+See [USAGE.md](USAGE.md) for more details on importing mbox files.
 
 ## Security and Privacy
 
@@ -306,7 +344,16 @@ The tool collects comprehensive metrics:
     "bytes_per_second": 6553600
   }
 }
-```
+  ```
+
+## Tools
+
+- **`gmail-exporter`**: Main CLI application
+- **`split-mbox-emails.py`**: Helper script to split mbox files into individual .eml files for importing
+  - Validates mbox format before processing
+  - Handles empty messages and malformed mbox files gracefully
+  - Supports verbose mode (`-v` or `--verbose`) for debugging
+  - Usage: `./split-mbox-emails.py <mbox_file> [output_dir] [options]`
 
 ## Contributing
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -137,24 +137,29 @@ credentials_file: "~/.gmail-exporter/credentials.json"
 token_file: "~/.gmail-exporter/token.json"
 
 # Default Export Settings
-output_dir: "./exports"
-organize_by_labels: false
-parallel_workers: 3
+ output_dir: "./exports"
+ organize_by_labels: false
+ parallel_workers: 3
 
 # Default Filters
-filters:
+ filters:
   exclude_chats: true
   search_scope: "all_mail"
 
 # Metrics Configuration
-metrics:
-  enabled: true
-  format: "json"
-  output_file: "metrics.json"
+ metrics:
+   enabled: true
+   format: "json"
+   output_file: "metrics.json"
 
 # Logging
-log_level: "info"
-log_file: ""
+ log_level: "info"
+ log_file: ""
+
+# Import Settings (optional)
+# skip_duplicates: false  # Skip emails already in Gmail (based on Message-ID)
+# labels: ""  # Override email labels (comma-separated)
+```
 ```
 
 ## Step 7: Monitoring and Metrics
@@ -178,6 +183,124 @@ After an export operation, check the metrics file:
 ```bash
 cat ./exports/metrics.json
 ```
+
+## Import Usage
+
+The import command allows you to import previously exported emails into a Gmail account. This is useful for:
+- Migrating emails between Gmail accounts
+- Restoring emails from backups
+- Importing emails from other email systems (after export)
+- Testing import functionality
+
+### Basic Import
+
+```bash
+./gmail-exporter import --input-dir ./exports
+```
+
+### Import with Label Preservation
+
+Emails exported from Gmail contain `X-Gmail-Labels` headers. The importer automatically extracts these labels and applies them during import:
+
+```bash
+./gmail-exporter import --input-dir ./exports
+```
+
+Labels are automatically:
+- Extracted from `X-Gmail-Labels` header
+- Normalized to Gmail API format (e.g., "Category Personal" → "CATEGORY_PERSONAL")
+- Resolved to actual Gmail label IDs
+
+### Import with Custom Labels
+
+Override email labels with your own labels:
+
+```bash
+./gmail-exporter import \
+  --input-dir ./exports \
+  --labels "important,work,projects"
+```
+
+This is useful when:
+- You want to reorganize emails during import
+- Exported emails have missing or incorrect labels
+- Migrating to a different label structure
+
+### Import with Deduplication
+
+Avoid importing duplicate emails by checking Message-ID against Gmail before importing:
+
+```bash
+./gmail-exporter import \
+  --input-dir ./exports \
+  --skip-duplicates
+```
+
+**When to use `--skip-duplicates`:**
+- Re-running imports after failures
+- Testing import process multiple times
+- Importing from multiple mbox files that may overlap
+- Any scenario where you might run import twice on the same data
+
+**How deduplication works:**
+1. Extracts `Message-ID` from email headers (RFC 5322 format)
+2. Queries Gmail API with `rfc822msgid:<id>` to check if message exists
+3. Skips import if message already found in Gmail
+4. Reports count of skipped duplicates in output
+
+### Complete Import Workflow
+
+Here's a complete workflow for migrating emails from one account to another:
+
+```bash
+# Step 1: Export from source account
+./gmail-exporter export \
+  --to "old-account@gmail.com" \
+  --output-dir migration-exports \
+  --organize-by-labels
+
+# Step 2: Test import with a few messages
+./gmail-exporter import \
+  --input-dir migration-exports \
+  --limit 10 \
+  --skip-duplicates
+
+# Step 3: If test successful, import all
+./gmail-exporter import \
+  --input-dir migration-exports \
+  --skip-duplicates \
+  --parallel-workers 3
+```
+
+### Import Configuration
+
+You can set import-specific options in your config file:
+
+```yaml
+# ~/.gmail-exporter.yaml
+import:
+  input_dir: "./exports"
+  parallel_workers: 3
+  preserve_dates: true
+  skip_duplicates: false  # Enable to avoid duplicates
+  labels: ""  # Override with comma-separated labels
+```
+
+### Import Metrics
+
+After import completes, check the metrics file:
+
+```bash
+cat import_metrics.json
+```
+
+This includes:
+- `total_found`: Total files processed
+- `total_imported`: Successfully imported emails
+- `total_failed`: Failed imports
+- `total_skipped`: Duplicates skipped (with --skip-duplicates)
+- `total_size`: Total size imported
+- `duration`: Time taken
 
 ## Common Use Cases
 
@@ -214,10 +337,13 @@ cat ./exports/metrics.json
 
 ```bash
 ./gmail-exporter export \
+  --to "user@example.com" \
   --labels "important,work" \
   --organize-by-labels \
   --output-dir ./labeled-emails
 ```
+
+**Note:** Labels are preserved in exports via `X-Gmail-Labels` header and will be automatically applied when importing to another Gmail account.
 
 ### 5. Complete Workflow (Export + Forward + Archive)
 
@@ -227,6 +353,27 @@ cat ./exports/metrics.json
   --destination "backup@example.com" \
   --cleanup-action archive \
   --output-dir ./exports
+```
+
+### 6. Safe Import Testing
+
+When testing imports, use deduplication to avoid creating test duplicates in Gmail:
+
+```bash
+# First, export a small test set
+./gmail-exporter export \
+  --to "test@example.com" \
+  --limit 5 \
+  --output-dir test-exports
+
+# Test import with deduplication enabled
+./gmail-exporter import \
+  --input-dir test-exports \
+  --skip-duplicates \
+  --limit 5
+
+# If successful, you can re-run import without --skip-duplicates on the full export
+# without creating duplicate emails
 ```
 
 ## Troubleshooting
@@ -288,11 +435,24 @@ For large exports:
 | `--size-less-than` | Email size threshold | `--size-less-than "10MB"` |
 | `--date-within` | Date range | `--date-within "30d"` |
 | `--date-after` | After specific date | `--date-after "2024-01-01"` |
-| `--date-before` | Before specific date | `--date-before "2024-12-31"` |
+ | `--date-before` | Before specific date | `--date-before "2024-12-31"` |
 | `--has-attachment` | Has attachments | `--has-attachment` |
 | `--no-attachment` | No attachments | `--no-attachment` |
 | `--exclude-chats` | Exclude chat messages | `--exclude-chats` |
 | `--labels` | Specific labels | `--labels "important,work"` |
+
+## Import Filter Reference
+
+| Flag | Description | Example |
+|--------|-------------|---------|
+| `--input-dir` | Input directory containing exported emails | `--input-dir ./exports` |
+| `--import-credentials` | Gmail API credentials file for destination account | `--import-credentials dest-creds.json` |
+| `--import-token` | OAuth token file for destination account | `--import-token dest-token.json` |
+| `--parallel-workers` | Number of parallel workers | `--parallel-workers 3` |
+| `--preserve-dates` | Preserve original email dates | `--preserve-dates` |
+| `--limit` | Limit to number of messages to process | `--limit 100` |
+| `--labels` | Gmail labels to apply to imported emails (overrides X-Gmail-Labels header) | `--labels "tickets,music"` |
+| `--skip-duplicates` | Skip emails that already exist in Gmail (based on Message-ID) | `--skip-duplicates` |
 
 ## Security Notes
 
@@ -381,7 +541,8 @@ Here's a complete example of migrating emails from one account to another:
   --import-credentials dest-gmail-credentials.json \
   --import-token dest-gmail-token.json \
   --limit 5 \
-  --preserve-dates
+  --preserve-dates \
+  --skip-duplicates
 
 # Step 3: If test successful, import all
 ./gmail-exporter import \
@@ -389,15 +550,8 @@ Here's a complete example of migrating emails from one account to another:
   --import-credentials dest-gmail-credentials.json \
   --import-token dest-gmail-token.json \
   --preserve-dates \
+  --skip-duplicates \
   --parallel-workers 3
-
-# Step 4: Optional - Clean up source account
-./gmail-exporter cleanup \
-  --credentials-file source-gmail-credentials.json \
-  --token-file source-gmail-token.json \
-  --action archive \
-  --filter-file migration-2024/processed_emails.json \
-  --dry-run  # Remove this flag when ready to execute
 ```
 
 ### Account-Specific Configuration
@@ -566,15 +720,21 @@ Before running large migrations:
 ### Import Issues
 
 **Problem:** Emails not appearing in destination account
-
 - Verify you're using correct destination credentials
 - Check that import completed without errors
 - Look in "All Mail" folder, not just Inbox
 
 **Problem:** Duplicate emails during import
+- Use `--skip-duplicates` flag to avoid importing emails that already exist in Gmail
+- This checks for duplicates by Message-ID before importing
+- Useful when re-running imports after failures or testing
+- With `--skip-duplicates` enabled, check output for "Total emails skipped (duplicates)" count
 
-- This was a bug in earlier versions - ensure you're using latest version
-- The tool now uses Gmail API Import instead of Send
+**Problem:** Labels not being applied
+- Ensure emails have `X-Gmail-Labels` header when exported
+- Check that label names match your Gmail labels (case-sensitive)
+- Use `--labels` flag to override email labels if needed
+- Labels like "Archived" and "Opened" are skipped (they're not Gmail labels)
 
 ### Performance Issues
 

--- a/import-all.sh
+++ b/import-all.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+# Gmail Import Batch Script
+# Imports all main Gmail folders from Google Takeout
+
+set -e  # Exit on error
+
+# Configuration
+MAIL_DIR="/Volumes/Samsung 2T/GoogleTakeout_2025-11/Mail"
+OUTPUT_DIR="2-split-to-import"
+IMPORT_DATE=$(date +"%Y-%m-%d")
+SPLITTER_SCRIPT="./split-mbox-emails-streaming.py"
+IMPORT_CMD="./gmail-exporter"
+
+# Colors for output
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+# Helper functions
+log_info() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+log_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+log_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Check if files exist
+check_files() {
+    local file="$1"
+    if [ ! -f "$file" ]; then
+        log_error "File not found: $file"
+        exit 1
+    fi
+}
+
+# Import a single mbox file
+import_mbox() {
+    local mbox_file="$1"
+    local label_type="$2"
+    local extra_flags="$3"
+
+    local filename=$(basename "$mbox_file")
+    local import_label="import-${label_type}-${IMPORT_DATE}"
+
+    log_info "Processing: $filename"
+    log_info "Import label: $import_label"
+
+    # Check if file exists
+    check_files "$mbox_file"
+
+    # Clear output directory and split mbox
+    log_info "Splitting $filename..."
+    if [ -d "$OUTPUT_DIR" ]; then
+        rm -rf "$OUTPUT_DIR"
+    fi
+
+    $SPLITTER_SCRIPT "$mbox_file" --clear
+
+    # Import with appropriate flags
+    log_info "Importing $filename to Gmail..."
+    $IMPORT_CMD import \
+        --skip-duplicates \
+        --skip-categories \
+        $extra_flags \
+        --input-dir "$OUTPUT_DIR" \
+        --add-label="$import_label"
+
+    log_success "Imported $filename"
+    echo ""
+}
+
+# Main execution
+echo ""
+echo "=========================================="
+echo "Gmail Import Batch Script"
+echo "=========================================="
+echo "Import date: $IMPORT_DATE"
+echo "Mail directory: $MAIL_DIR"
+echo "=========================================="
+echo ""
+echo "⚠️  IMPORTANT: Before starting import, make sure you've created these labels in Gmail:"
+echo "     1. import-inbox-$IMPORT_DATE"
+echo "     2. import-sent-$IMPORT_DATE"
+echo "     3. import-starred-$IMPORT_DATE"
+echo "     4. import-archived-$IMPORT_DATE"
+echo ""
+echo "💡 How to create labels in Gmail:"
+echo "     1. Open Gmail (https://mail.google.com)"
+echo "     2. Click 'Labels' on left sidebar"
+echo "     3. Click '+ Create' button"
+echo "     4. Enter label name (e.g., import-inbox-$IMPORT_DATE)"
+echo "     5. Click 'Create'"
+echo ""
+read -p "Press ENTER to continue once labels are created, or Ctrl+C to exit..."
+
+echo ""
+echo "=========================================="
+echo ""
+
+# Import Inbox (received emails)
+import_mbox \
+    "$MAIL_DIR/Inbox.mbox" \
+    "inbox" \
+    "--no-inbox --no-starred --no-important"
+
+# Import Sent emails
+import_mbox \
+    "$MAIL_DIR/Sent.mbox" \
+    "sent" \
+    "--no-inbox"
+
+# Import Starred emails
+import_mbox \
+    "$MAIL_DIR/Starred.mbox" \
+    "starred" \
+    "--no-inbox --no-starred"
+
+# Import Archived emails
+import_mbox \
+    "$MAIL_DIR/Archived.mbox" \
+    "archived" \
+    "--no-inbox"
+
+# Final summary
+echo ""
+echo "=========================================="
+echo -e "${GREEN}[ALL DONE]${NC}"
+echo "=========================================="
+echo ""
+echo "All imports completed successfully!"
+echo ""
+echo "To verify in Gmail:"
+echo "  1. Open Gmail"
+echo "  2. Search for: import-$IMPORT_DATE"
+echo "  3. You should see all imported emails with the following labels:"
+echo "     - import-inbox-$IMPORT_DATE"
+echo "     - import-sent-$IMPORT_DATE"
+echo "     - import-starred-$IMPORT_DATE"
+echo "     - import-archived-$IMPORT_DATE"
+echo ""

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -23,8 +23,13 @@ The import command uses separate credentials from export to allow importing into
 Gmail account. Use --import-credentials and --import-token to specify different authentication
 files for the destination account.
 
+LABELS:
+Use --labels to apply Gmail labels to imported emails. Labels are specified as a
+comma-separated list of label names (e.g., --labels "tickets,music"). The tool will
+automatically resolve label names to their corresponding Gmail label IDs.
+
 Use --limit to process only a specific number of messages, which is useful for testing
-the import process with a small number of messages before running a full import.`,
+import process with a small number of messages before running a full import.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Build import configuration from flags
 		importConfig, err := buildImportConfig(cmd)
@@ -72,6 +77,7 @@ func init() {
 	importCmd.Flags().Int("parallel-workers", 3, "Number of parallel workers")
 	importCmd.Flags().Bool("preserve-dates", true, "Preserve original email dates")
 	importCmd.Flags().IntP("limit", "l", 0, "Limit the number of messages to process (0 = no limit, useful for testing)")
+	importCmd.Flags().String("labels", "", "Gmail labels to apply to imported emails (comma-separated)")
 }
 
 func buildImportConfig(cmd *cobra.Command) (*importer.Config, error) {
@@ -104,6 +110,9 @@ func buildImportConfig(cmd *cobra.Command) (*importer.Config, error) {
 	}
 	if limit, _ := cmd.Flags().GetInt("limit"); limit > 0 {
 		config.Limit = limit
+	}
+	if labels, _ := cmd.Flags().GetString("labels"); labels != "" {
+		config.Labels = labels
 	}
 
 	// Validate required fields

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -33,14 +33,20 @@ Use --skip-duplicates to avoid importing emails that already exist in Gmail. Thi
 for existing messages by Message-ID before importing. Enabling this will skip duplicates
 and log the count of skipped messages.
 
-INBOX LABEL EXCLUSION:
+LABEL EXCLUSION:
 Use --no-inbox to prevent the "Inbox" label from being applied to imported
 emails. This is useful when you want imported emails to inherit their original
 labels without automatically adding them to the Inbox folder. When enabled, emails with
 "Inbox" in their X-Gmail-Labels header will have that label excluded during import.
 
+Use --no-important to prevent the "Important" label from being applied.
+Use --no-starred to prevent the "Starred" label from being applied.
+
+Use --all-archived to archive all imported emails (removes INBOX label).
+This is useful when importing emails that should not appear in the inbox.
+
 Use --limit to process only a specific number of messages, which is useful for testing
--import process with a small number of messages before running a full import.`,
+the import process with a small number of messages before running a full import.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Build import configuration from flags
 		importConfig, err := buildImportConfig(cmd)
@@ -94,6 +100,9 @@ func init() {
 	importCmd.Flags().String("labels", "", "Gmail labels to apply to imported emails (comma-separated)")
 	importCmd.Flags().Bool("skip-duplicates", false, "Skip emails that already exist in Gmail (based on Message-ID)")
 	importCmd.Flags().Bool("no-inbox", false, "Exclude Inbox label from imported emails (based on X-Gmail-Labels)")
+	importCmd.Flags().Bool("no-important", false, "Exclude Important label from imported emails (based on X-Gmail-Labels)")
+	importCmd.Flags().Bool("no-starred", false, "Exclude Starred label from imported emails (based on X-Gmail-Labels)")
+	importCmd.Flags().Bool("all-archived", false, "Archive all imported emails (removes INBOX label)")
 }
 
 func buildImportConfig(cmd *cobra.Command) (*importer.Config, error) {
@@ -135,6 +144,15 @@ func buildImportConfig(cmd *cobra.Command) (*importer.Config, error) {
 	}
 	if skipInbox, _ := cmd.Flags().GetBool("no-inbox"); skipInbox {
 		config.SkipInboxLabel = skipInbox
+	}
+	if skipImportant, _ := cmd.Flags().GetBool("no-important"); skipImportant {
+		config.SkipImportantLabel = skipImportant
+	}
+	if skipStarred, _ := cmd.Flags().GetBool("no-starred"); skipStarred {
+		config.SkipStarredLabel = skipStarred
+	}
+	if archiveAll, _ := cmd.Flags().GetBool("all-archived"); archiveAll {
+		config.ArchiveAll = archiveAll
 	}
 
 	// Validate required fields

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -42,9 +42,6 @@ labels without automatically adding them to the Inbox folder. When enabled, emai
 Use --no-important to prevent the "Important" label from being applied.
 Use --no-starred to prevent the "Starred" label from being applied.
 
-Use --all-archived to archive all imported emails (removes INBOX label).
-This is useful when importing emails that should not appear in the inbox.
-
 Use --limit to process only a specific number of messages, which is useful for testing
 the import process with a small number of messages before running a full import.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -102,7 +99,6 @@ func init() {
 	importCmd.Flags().Bool("no-inbox", false, "Exclude Inbox label from imported emails (based on X-Gmail-Labels)")
 	importCmd.Flags().Bool("no-important", false, "Exclude Important label from imported emails (based on X-Gmail-Labels)")
 	importCmd.Flags().Bool("no-starred", false, "Exclude Starred label from imported emails (based on X-Gmail-Labels)")
-	importCmd.Flags().Bool("all-archived", false, "Archive all imported emails (removes INBOX label)")
 }
 
 func buildImportConfig(cmd *cobra.Command) (*importer.Config, error) {
@@ -150,9 +146,6 @@ func buildImportConfig(cmd *cobra.Command) (*importer.Config, error) {
 	}
 	if skipStarred, _ := cmd.Flags().GetBool("no-starred"); skipStarred {
 		config.SkipStarredLabel = skipStarred
-	}
-	if archiveAll, _ := cmd.Flags().GetBool("all-archived"); archiveAll {
-		config.ArchiveAll = archiveAll
 	}
 
 	// Validate required fields

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -28,8 +28,13 @@ Use --labels to apply Gmail labels to imported emails. Labels are specified as a
 comma-separated list of label names (e.g., --labels "tickets,music"). The tool will
 automatically resolve label names to their corresponding Gmail label IDs.
 
+DEDUPLICATION:
+Use --skip-duplicates to avoid importing emails that already exist in Gmail. This checks
+for existing messages by Message-ID before importing. Enabling this will skip duplicates
+and log the count of skipped messages.
+
 Use --limit to process only a specific number of messages, which is useful for testing
-import process with a small number of messages before running a full import.`,
+-import process with a small number of messages before running a full import.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Build import configuration from flags
 		importConfig, err := buildImportConfig(cmd)
@@ -59,6 +64,9 @@ import process with a small number of messages before running a full import.`,
 		fmt.Printf("Import completed successfully!\n")
 		fmt.Printf("Total files found: %d\n", result.TotalFound)
 		fmt.Printf("Total emails imported: %d\n", result.TotalImported)
+		if result.TotalSkipped > 0 {
+			fmt.Printf("Total emails skipped (duplicates): %d\n", result.TotalSkipped)
+		}
 		fmt.Printf("Total size: %s\n", metrics.FormatBytes(result.TotalSize))
 		fmt.Printf("Duration: %s\n", result.Duration)
 
@@ -78,6 +86,7 @@ func init() {
 	importCmd.Flags().Bool("preserve-dates", true, "Preserve original email dates")
 	importCmd.Flags().IntP("limit", "l", 0, "Limit the number of messages to process (0 = no limit, useful for testing)")
 	importCmd.Flags().String("labels", "", "Gmail labels to apply to imported emails (comma-separated)")
+	importCmd.Flags().Bool("skip-duplicates", false, "Skip emails that already exist in Gmail (based on Message-ID)")
 }
 
 func buildImportConfig(cmd *cobra.Command) (*importer.Config, error) {
@@ -113,6 +122,9 @@ func buildImportConfig(cmd *cobra.Command) (*importer.Config, error) {
 	}
 	if labels, _ := cmd.Flags().GetString("labels"); labels != "" {
 		config.Labels = labels
+	}
+	if skipDuplicates, _ := cmd.Flags().GetBool("skip-duplicates"); skipDuplicates {
+		config.SkipDuplicates = skipDuplicates
 	}
 
 	// Validate required fields

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -23,7 +23,7 @@ The import command uses separate credentials from export to allow importing into
 Gmail account. Use --import-credentials and --import-token to specify different authentication
 files for the destination account.
 
-LABELS:
+	LABELS:
 Use --labels to apply Gmail labels to imported emails. Labels are specified as a
 comma-separated list of label names (e.g., --labels "tickets,music"). The tool will
 automatically resolve label names to their corresponding Gmail label IDs.
@@ -32,6 +32,12 @@ DEDUPLICATION:
 Use --skip-duplicates to avoid importing emails that already exist in Gmail. This checks
 for existing messages by Message-ID before importing. Enabling this will skip duplicates
 and log the count of skipped messages.
+
+INBOX LABEL EXCLUSION:
+Use --no-inbox to prevent the "Inbox" label from being applied to imported
+emails. This is useful when you want imported emails to inherit their original
+labels without automatically adding them to the Inbox folder. When enabled, emails with
+"Inbox" in their X-Gmail-Labels header will have that label excluded during import.
 
 Use --limit to process only a specific number of messages, which is useful for testing
 -import process with a small number of messages before running a full import.`,
@@ -84,9 +90,10 @@ func init() {
 	importCmd.Flags().String("import-token", "", "OAuth token file for destination account (defaults to main token)")
 	importCmd.Flags().Int("parallel-workers", 3, "Number of parallel workers")
 	importCmd.Flags().Bool("preserve-dates", true, "Preserve original email dates")
-	importCmd.Flags().IntP("limit", "l", 0, "Limit the number of messages to process (0 = no limit, useful for testing)")
+	importCmd.Flags().IntP("limit", "l", 0, "Limit number of messages to process (0 = no limit, useful for testing)")
 	importCmd.Flags().String("labels", "", "Gmail labels to apply to imported emails (comma-separated)")
 	importCmd.Flags().Bool("skip-duplicates", false, "Skip emails that already exist in Gmail (based on Message-ID)")
+	importCmd.Flags().Bool("no-inbox", false, "Exclude Inbox label from imported emails (based on X-Gmail-Labels)")
 }
 
 func buildImportConfig(cmd *cobra.Command) (*importer.Config, error) {
@@ -125,6 +132,9 @@ func buildImportConfig(cmd *cobra.Command) (*importer.Config, error) {
 	}
 	if skipDuplicates, _ := cmd.Flags().GetBool("skip-duplicates"); skipDuplicates {
 		config.SkipDuplicates = skipDuplicates
+	}
+	if skipInbox, _ := cmd.Flags().GetBool("no-inbox"); skipInbox {
+		config.SkipInboxLabel = skipInbox
 	}
 
 	// Validate required fields

--- a/internal/cli/import.go
+++ b/internal/cli/import.go
@@ -27,6 +27,16 @@ files for the destination account.
 Use --labels to apply Gmail labels to imported emails. Labels are specified as a
 comma-separated list of label names (e.g., --labels "tickets,music"). The tool will
 automatically resolve label names to their corresponding Gmail label IDs.
+When --labels is used, it replaces any labels extracted from the email headers.
+
+Use --add-label to add a single label to all imported emails, in addition to any
+labels from the email headers or --labels flag. This is useful for identifying
+imported emails (e.g., --add-label="import-2026-0205").
+
+IMPORTANT: The label specified in --add-label must already exist in your Gmail account
+before running the import. You must create the label manually in Gmail's web interface
+or via the Gmail API first. If the label doesn't exist, the import will still succeed
+but the label won't be applied (a warning will be logged).
 
 DEDUPLICATION:
 Use --skip-duplicates to avoid importing emails that already exist in Gmail. This checks
@@ -41,6 +51,12 @@ labels without automatically adding them to the Inbox folder. When enabled, emai
 
 Use --no-important to prevent the "Important" label from being applied.
 Use --no-starred to prevent the "Starred" label from being applied.
+
+Use --skip-categories to prevent Gmail category labels from being applied. Gmail
+categories (Personal, Social, Promotions, Updates, Forums, Purchases) are
+system-managed labels that Gmail assigns automatically based on email content. These
+cannot be set via API during import and will be ignored by default. Use this flag
+to suppress the warning messages.
 
 Use --limit to process only a specific number of messages, which is useful for testing
 the import process with a small number of messages before running a full import.`,
@@ -94,11 +110,13 @@ func init() {
 	importCmd.Flags().Int("parallel-workers", 3, "Number of parallel workers")
 	importCmd.Flags().Bool("preserve-dates", true, "Preserve original email dates")
 	importCmd.Flags().IntP("limit", "l", 0, "Limit number of messages to process (0 = no limit, useful for testing)")
-	importCmd.Flags().String("labels", "", "Gmail labels to apply to imported emails (comma-separated)")
+	importCmd.Flags().String("labels", "", "Gmail labels to apply to imported emails (comma-separated, replaces email labels)")
+	importCmd.Flags().String("add-label", "", "Gmail label to add to all imported emails (label must exist in Gmail first)")
 	importCmd.Flags().Bool("skip-duplicates", false, "Skip emails that already exist in Gmail (based on Message-ID)")
 	importCmd.Flags().Bool("no-inbox", false, "Exclude Inbox label from imported emails (based on X-Gmail-Labels)")
 	importCmd.Flags().Bool("no-important", false, "Exclude Important label from imported emails (based on X-Gmail-Labels)")
 	importCmd.Flags().Bool("no-starred", false, "Exclude Starred label from imported emails (based on X-Gmail-Labels)")
+	importCmd.Flags().Bool("skip-categories", false, "Skip Gmail category labels (Personal, Social, Promotions, Updates, Forums, Purchases)")
 }
 
 func buildImportConfig(cmd *cobra.Command) (*importer.Config, error) {
@@ -135,6 +153,9 @@ func buildImportConfig(cmd *cobra.Command) (*importer.Config, error) {
 	if labels, _ := cmd.Flags().GetString("labels"); labels != "" {
 		config.Labels = labels
 	}
+	if addLabel, _ := cmd.Flags().GetString("add-label"); addLabel != "" {
+		config.AddLabel = addLabel
+	}
 	if skipDuplicates, _ := cmd.Flags().GetBool("skip-duplicates"); skipDuplicates {
 		config.SkipDuplicates = skipDuplicates
 	}
@@ -146,6 +167,9 @@ func buildImportConfig(cmd *cobra.Command) (*importer.Config, error) {
 	}
 	if skipStarred, _ := cmd.Flags().GetBool("no-starred"); skipStarred {
 		config.SkipStarredLabel = skipStarred
+	}
+	if skipCategories, _ := cmd.Flags().GetBool("skip-categories"); skipCategories {
+		config.SkipCategories = skipCategories
 	}
 
 	// Validate required fields

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -20,15 +20,18 @@ import (
 
 // Config represents the importer configuration
 type Config struct {
-	CredentialsFile string `json:"credentials_file"`
-	TokenFile       string `json:"token_file"`
-	InputDir        string `json:"input_dir"`
-	ParallelWorkers int    `json:"parallel_workers"`
-	PreserveDates   bool   `json:"preserve_dates"`
-	Limit           int    `json:"limit"`
-	Labels          string `json:"labels"`
-	SkipDuplicates  bool   `json:"skip_duplicates"`
-	SkipInboxLabel  bool   `json:"skip_inbox_label"`
+	CredentialsFile    string `json:"credentials_file"`
+	TokenFile          string `json:"token_file"`
+	InputDir           string `json:"input_dir"`
+	ParallelWorkers    int    `json:"parallel_workers"`
+	PreserveDates      bool   `json:"preserve_dates"`
+	Limit              int    `json:"limit"`
+	Labels             string `json:"labels"`
+	SkipDuplicates     bool   `json:"skip_duplicates"`
+	SkipInboxLabel     bool   `json:"skip_inbox_label"`
+	SkipImportantLabel bool   `json:"skip_important_label"`
+	SkipStarredLabel   bool   `json:"skip_starred_label"`
+	ArchiveAll         bool   `json:"archive_all"`
 }
 
 // Result represents the import operation result
@@ -433,6 +436,21 @@ func (i *Importer) getLabelIdsForEmail(data []byte) []string {
 	}
 
 	logrus.WithFields(logrus.Fields{"email_labels": emailLabels, "resolved_count": len(labelIds)}).Debug("Processed email labels")
+
+	// Handle --all-archived flag: remove INBOX label if present
+	if i.config.ArchiveAll {
+		filteredLabels := make([]string, 0, len(labelIds))
+		for _, labelId := range labelIds {
+			if labelId != "INBOX" {
+				filteredLabels = append(filteredLabels, labelId)
+			}
+		}
+		if len(filteredLabels) < len(labelIds) {
+			logrus.Debug("Removing INBOX label due to --all-archived flag")
+		}
+		return filteredLabels
+	}
+
 	return labelIds
 }
 
@@ -518,10 +536,18 @@ func (i *Importer) normalizeLabelName(labelName string) string {
 
 // resolveLabelName resolves a single label name to its ID (with caching)
 func (i *Importer) resolveLabelName(labelName string) string {
-	// Skip "Inbox" label if configured
+	// Skip labels if configured
 	upper := strings.ToUpper(labelName)
 	if upper == "INBOX" && i.config.SkipInboxLabel {
 		logrus.WithField("label", labelName).Debug("Skipping Inbox label per configuration")
+		return ""
+	}
+	if upper == "IMPORTANT" && i.config.SkipImportantLabel {
+		logrus.WithField("label", labelName).Debug("Skipping Important label per configuration")
+		return ""
+	}
+	if upper == "STARRED" && i.config.SkipStarredLabel {
+		logrus.WithField("label", labelName).Debug("Skipping Starred label per configuration")
 		return ""
 	}
 

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -27,6 +27,7 @@ type Config struct {
 	PreserveDates   bool   `json:"preserve_dates"`
 	Limit           int    `json:"limit"`
 	Labels          string `json:"labels"`
+	SkipDuplicates  bool   `json:"skip_duplicates"`
 }
 
 // Result represents the import operation result
@@ -34,6 +35,7 @@ type Result struct {
 	TotalFound    int           `json:"total_found"`
 	TotalImported int           `json:"total_imported"`
 	TotalFailed   int           `json:"total_failed"`
+	TotalSkipped  int           `json:"total_skipped"`
 	TotalSize     int64         `json:"total_size"`
 	Duration      time.Duration `json:"duration"`
 	Failures      []Failure     `json:"failures,omitempty"`
@@ -222,14 +224,19 @@ func (i *Importer) importEmails(emailFiles []string) (*Result, error) {
 				Timestamp: time.Now(),
 			})
 			logrus.WithError(importRes.Error).WithField("file_path", importRes.FilePath).Error("Failed to import email")
+		} else if importRes.Size == 0 {
+			// Email was skipped (e.g., duplicate)
+			result.TotalSkipped++
+			logrus.WithField("file_path", importRes.FilePath).Debug("Skipped email")
 		} else {
 			result.TotalImported++
 			result.TotalSize += importRes.Size
 		}
 
-		// Show progress
-		fmt.Printf("\rProgress: %d of %d messages imported (%.1f%%)",
-			result.TotalImported, total, float64(processed)/float64(total)*100)
+		// Show progress (imported + skipped)
+		completed := result.TotalImported + result.TotalSkipped
+		fmt.Printf("\rProgress: %d of %d messages processed (%.1f%%)",
+			completed, total, float64(processed)/float64(total)*100)
 	}
 	fmt.Println() // New line after progress
 
@@ -284,6 +291,20 @@ func (i *Importer) importEMLFile(data []byte) (int64, error) {
 	// Extract labels from email headers
 	labelIds := i.getLabelIdsForEmail(data)
 
+	// Check for duplicates if enabled
+	if i.config.SkipDuplicates {
+		messageID := i.extractMessageID(data)
+		if messageID != "" {
+			exists, err := i.messageExists(messageID)
+			if err != nil {
+				logrus.WithError(err).WithField("message_id", messageID).Warn("Failed to check if message exists, proceeding with import")
+			} else if exists {
+				logrus.WithField("message_id", messageID).Info("Message already exists in Gmail, skipping")
+				return 0, nil
+			}
+		}
+	}
+
 	// Create a Gmail message from the EML data
 	message := &gmail.Message{
 		Raw:      encodeBase64URL(data),
@@ -316,6 +337,21 @@ func (i *Importer) importJSONFile(data []byte) (int64, error) {
 		// If decoding fails, just use the raw as-is
 		rawBytes = []byte(emailData.Raw)
 	}
+
+	// Check for duplicates if enabled
+	if i.config.SkipDuplicates {
+		messageID := i.extractMessageID(rawBytes)
+		if messageID != "" {
+			exists, err := i.messageExists(messageID)
+			if err != nil {
+				logrus.WithError(err).WithField("message_id", messageID).Warn("Failed to check if message exists, proceeding with import")
+			} else if exists {
+				logrus.WithField("message_id", messageID).Info("Message already exists in Gmail, skipping")
+				return 0, nil
+			}
+		}
+	}
+
 	labelIds := i.getLabelIdsForEmail(rawBytes)
 
 	// Create a Gmail message
@@ -543,6 +579,67 @@ func validateConfig(config *Config) error {
 	}
 
 	return nil
+}
+
+// extractMessageID extracts the Message-ID header from email data
+func (i *Importer) extractMessageID(data []byte) string {
+	dataStr := string(data)
+
+	// Find the Message-ID header
+	headerPrefix := "\nMessage-ID:"
+	idx := strings.Index(dataStr, headerPrefix)
+	if idx == -1 {
+		// Try with lowercase
+		headerPrefix = "\nmessage-id:"
+		idx = strings.Index(dataStr, headerPrefix)
+		if idx == -1 {
+			return ""
+		}
+	}
+
+	// Extract the header value (up to the next line)
+	start := idx + len(headerPrefix)
+	end := len(dataStr)
+
+	for i := start; i < len(dataStr); i++ {
+		if dataStr[i] == '\n' {
+			end = i
+			break
+		}
+	}
+
+	messageID := strings.TrimSpace(dataStr[start:end])
+
+	// Remove angle brackets and any trailing parameters
+	messageID = strings.Trim(messageID, "<>")
+
+	// Extract just the ID part before parameters (like ; or space)
+	if idx := strings.IndexAny(messageID, ";\t "); idx >= 0 {
+		messageID = messageID[:idx]
+	}
+
+	messageID = strings.TrimSpace(messageID)
+
+	return messageID
+}
+
+// messageExists checks if a message with the given Message-ID already exists in Gmail
+func (i *Importer) messageExists(messageID string) (bool, error) {
+	if messageID == "" {
+		return false, nil
+	}
+
+	// Search for message with this Message-ID
+	q := fmt.Sprintf("rfc822msgid:%s", messageID)
+
+	listCall := i.gmailService.Users.Messages.List("me").Q(q).MaxResults(1)
+	resp, err := listCall.Do()
+	if err != nil {
+		return false, fmt.Errorf("failed to check if message exists: %w", err)
+	}
+
+	// If we get any results, the message exists
+	return len(resp.Messages) > 0, nil
 }
 
 // encodeBase64URL encodes data in base64url format for Gmail API

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -31,7 +31,6 @@ type Config struct {
 	SkipInboxLabel     bool   `json:"skip_inbox_label"`
 	SkipImportantLabel bool   `json:"skip_important_label"`
 	SkipStarredLabel   bool   `json:"skip_starred_label"`
-	ArchiveAll         bool   `json:"archive_all"`
 }
 
 // Result represents the import operation result
@@ -436,21 +435,6 @@ func (i *Importer) getLabelIdsForEmail(data []byte) []string {
 	}
 
 	logrus.WithFields(logrus.Fields{"email_labels": emailLabels, "resolved_count": len(labelIds)}).Debug("Processed email labels")
-
-	// Handle --all-archived flag: remove INBOX label if present
-	if i.config.ArchiveAll {
-		filteredLabels := make([]string, 0, len(labelIds))
-		for _, labelId := range labelIds {
-			if labelId != "INBOX" {
-				filteredLabels = append(filteredLabels, labelId)
-			}
-		}
-		if len(filteredLabels) < len(labelIds) {
-			logrus.Debug("Removing INBOX label due to --all-archived flag")
-		}
-		return filteredLabels
-	}
-
 	return labelIds
 }
 

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -28,6 +28,7 @@ type Config struct {
 	Limit           int    `json:"limit"`
 	Labels          string `json:"labels"`
 	SkipDuplicates  bool   `json:"skip_duplicates"`
+	SkipInboxLabel  bool   `json:"skip_inbox_label"`
 }
 
 // Result represents the import operation result
@@ -517,6 +518,13 @@ func (i *Importer) normalizeLabelName(labelName string) string {
 
 // resolveLabelName resolves a single label name to its ID (with caching)
 func (i *Importer) resolveLabelName(labelName string) string {
+	// Skip "Inbox" label if configured
+	upper := strings.ToUpper(labelName)
+	if upper == "INBOX" && i.config.SkipInboxLabel {
+		logrus.WithField("label", labelName).Debug("Skipping Inbox label per configuration")
+		return ""
+	}
+
 	// Normalize label name first
 	normalizedName := i.normalizeLabelName(labelName)
 

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -27,10 +27,12 @@ type Config struct {
 	PreserveDates      bool   `json:"preserve_dates"`
 	Limit              int    `json:"limit"`
 	Labels             string `json:"labels"`
+	AddLabel           string `json:"add_label"`
 	SkipDuplicates     bool   `json:"skip_duplicates"`
 	SkipInboxLabel     bool   `json:"skip_inbox_label"`
 	SkipImportantLabel bool   `json:"skip_important_label"`
 	SkipStarredLabel   bool   `json:"skip_starred_label"`
+	SkipCategories     bool   `json:"skip_categories"`
 }
 
 // Result represents the import operation result
@@ -238,8 +240,14 @@ func (i *Importer) importEmails(emailFiles []string) (*Result, error) {
 
 		// Show progress (imported + skipped)
 		completed := result.TotalImported + result.TotalSkipped
-		fmt.Printf("\rProgress: %d of %d messages processed (%.1f%%)",
-			completed, total, float64(processed)/float64(total)*100)
+		// Add newline after progress if debug logging is enabled to avoid running into debug lines
+		if logrus.IsLevelEnabled(logrus.DebugLevel) {
+			fmt.Printf("\rProgress: %d of %d messages processed (%.1f%%)\n",
+				completed, total, float64(processed)/float64(total)*100)
+		} else {
+			fmt.Printf("\rProgress: %d of %d messages processed (%.1f%%)",
+				completed, total, float64(processed)/float64(total)*100)
+		}
 	}
 	fmt.Println() // New line after progress
 
@@ -392,6 +400,9 @@ func (i *Importer) importMboxFile(data []byte) (int64, error) {
 
 // getLabelIdsForEmail extracts labels from email headers and resolves them to IDs
 func (i *Importer) getLabelIdsForEmail(data []byte) []string {
+	var labelIds []string
+	var emailLabels []string
+
 	// Check if --labels flag is set (command-line labels)
 	if i.config.Labels != "" {
 		logrus.WithField("labels", i.config.Labels).Debug("Using --labels flag")
@@ -413,28 +424,68 @@ func (i *Importer) getLabelIdsForEmail(data []byte) []string {
 			}
 			i.labelCacheMutex.Unlock()
 		}
-		return i.labelIds
-	}
+		labelIds = i.labelIds
+	} else {
+		// Extract labels from X-Gmail-Labels header
+		emailLabels = i.extractLabelsFromHeaders(data)
 
-	// Extract labels from X-Gmail-Labels header
-	emailLabels := i.extractLabelsFromHeaders(data)
-	if len(emailLabels) == 0 {
-		return nil
-	}
+		if len(emailLabels) == 0 {
+			logrus.Debug("No labels found in email headers")
+		} else {
+			// Resolve label names to IDs
+			labelIds = make([]string, 0, len(emailLabels))
+			for _, labelName := range emailLabels {
+				labelName = strings.TrimSpace(labelName)
+				if labelName == "" {
+					continue
+				}
+				if labelId := i.resolveLabelName(labelName); labelId != "" {
+					labelIds = append(labelIds, labelId)
+				}
+			}
 
-	// Resolve label names to IDs
-	labelIds := make([]string, 0, len(emailLabels))
-	for _, labelName := range emailLabels {
-		labelName = strings.TrimSpace(labelName)
-		if labelName == "" {
-			continue
+			logrus.WithFields(logrus.Fields{"email_labels": emailLabels, "resolved_count": len(labelIds)}).Debug("Processed email labels")
+
+			// Log the actual labels that will be applied (only when debug level is enabled)
+			if logrus.IsLevelEnabled(logrus.DebugLevel) {
+				if len(labelIds) > 0 {
+					logrus.WithFields(logrus.Fields{
+						"email_labels": emailLabels,
+						"label_ids":    labelIds,
+					}).Debug("Labels that will be applied to email")
+				} else if len(emailLabels) > 0 {
+					logrus.WithFields(logrus.Fields{
+						"email_labels": emailLabels,
+					}).Debug("No labels could be resolved from email headers")
+				}
+			}
 		}
-		if labelId := i.resolveLabelName(labelName); labelId != "" {
-			labelIds = append(labelIds, labelId)
+	}
+
+	// Add --add-label if specified (this adds to whatever labels are already set)
+	if i.config.AddLabel != "" {
+		addLabel := strings.TrimSpace(i.config.AddLabel)
+		if addLabel != "" {
+			addLabelId := i.resolveLabelName(addLabel)
+			if addLabelId != "" {
+				// Check if label is already in the list to avoid duplicates
+				alreadyPresent := false
+				for _, id := range labelIds {
+					if id == addLabelId {
+						alreadyPresent = true
+						break
+					}
+				}
+				if !alreadyPresent {
+					labelIds = append(labelIds, addLabelId)
+					logrus.WithFields(logrus.Fields{"add_label": addLabel, "label_id": addLabelId}).Debug("Added --add-label to email")
+				}
+			} else {
+				logrus.WithField("add_label", addLabel).Warn("--add-label not found in Gmail, will not be applied")
+			}
 		}
 	}
 
-	logrus.WithFields(logrus.Fields{"email_labels": emailLabels, "resolved_count": len(labelIds)}).Debug("Processed email labels")
 	return labelIds
 }
 
@@ -482,28 +533,31 @@ func (i *Importer) extractLabelsFromHeaders(data []byte) []string {
 
 // normalizeLabelName normalizes label names from X-Gmail-Labels header to Gmail API format
 func (i *Importer) normalizeLabelName(labelName string) string {
+	// Check if this is a Gmail category label
+	if strings.HasPrefix(labelName, "Category ") {
+		// Gmail categories (Purchases, Personal, Social, Updates, Forums, Promotions)
+		// are system-managed and cannot be set via API during import
+		if i.config != nil && i.config.SkipCategories {
+			logrus.WithField("category", labelName).Debug("Skipping Gmail category per --skip-categories flag (email will still be imported)")
+			return ""
+		}
+		if i.config != nil {
+			logrus.WithField("category", labelName).Warn("Gmail categories are system-managed and cannot be applied during import (email will still be imported)")
+			logrus.WithField("suggestion", "Use --skip-categories to suppress this warning").Info("Suggestion")
+		}
+		return ""
+	}
+
 	// Common mappings from X-Gmail-Labels to Gmail API
 	mappings := map[string]string{
-		"Important":           "IMPORTANT",
-		"Starred":             "STARRED",
-		"Unread":              "UNREAD",
-		"Category Personal":   "CATEGORY_PERSONAL",
-		"Category Social":     "CATEGORY_SOCIAL",
-		"Category Updates":    "CATEGORY_UPDATES",
-		"Category Forums":     "CATEGORY_FORUMS",
-		"Category Promotions": "CATEGORY_PROMOTIONS",
+		"Important": "IMPORTANT",
+		"Starred":   "STARRED",
+		"Unread":    "UNREAD",
 	}
 
 	// Check for known mappings
 	if mapped, ok := mappings[labelName]; ok {
 		return mapped
-	}
-
-	// Convert "Category XXX" to "CATEGORY_XXX"
-	if strings.HasPrefix(labelName, "Category ") {
-		category := strings.TrimPrefix(labelName, "Category ")
-		category = strings.ToUpper(strings.ReplaceAll(category, " ", "_"))
-		return "CATEGORY_" + category
 	}
 
 	// Try uppercase for system labels
@@ -523,15 +577,15 @@ func (i *Importer) resolveLabelName(labelName string) string {
 	// Skip labels if configured
 	upper := strings.ToUpper(labelName)
 	if upper == "INBOX" && i.config.SkipInboxLabel {
-		logrus.WithField("label", labelName).Debug("Skipping Inbox label per configuration")
+		logrus.WithField("label", labelName).Debug("Skipping Inbox label per --no-inbox flag (email will still be imported)")
 		return ""
 	}
 	if upper == "IMPORTANT" && i.config.SkipImportantLabel {
-		logrus.WithField("label", labelName).Debug("Skipping Important label per configuration")
+		logrus.WithField("label", labelName).Debug("Skipping Important label per --no-important flag (email will still be imported)")
 		return ""
 	}
 	if upper == "STARRED" && i.config.SkipStarredLabel {
-		logrus.WithField("label", labelName).Debug("Skipping Starred label per configuration")
+		logrus.WithField("label", labelName).Debug("Skipping Starred label per --no-starred flag (email will still be imported)")
 		return ""
 	}
 
@@ -571,7 +625,7 @@ func (i *Importer) resolveLabelName(labelName string) string {
 	i.labelCacheMutex.RUnlock()
 
 	if !ok {
-		logrus.WithField("label", labelName).Debug("Label not found, skipping")
+		logrus.WithField("label", labelName).Debug("Label not found in Gmail, skipping this label (email will still be imported)")
 		return ""
 	}
 

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -26,6 +26,7 @@ type Config struct {
 	ParallelWorkers int    `json:"parallel_workers"`
 	PreserveDates   bool   `json:"preserve_dates"`
 	Limit           int    `json:"limit"`
+	Labels          string `json:"labels"`
 }
 
 // Result represents the import operation result
@@ -47,10 +48,14 @@ type Failure struct {
 
 // Importer handles email import operations
 type Importer struct {
-	config        *Config
-	authenticator *auth.Authenticator
-	gmailService  *gmail.Service
-	metrics       *metrics.Collector
+	config           *Config
+	authenticator    *auth.Authenticator
+	gmailService     *gmail.Service
+	metrics          *metrics.Collector
+	labelIds         []string
+	labelCache       map[string]string
+	labelCacheMutex  sync.RWMutex
+	allLabelsFetched bool
 }
 
 // New creates a new importer instance
@@ -100,6 +105,9 @@ func (i *Importer) Import() (*Result, error) {
 	}
 
 	logrus.WithField("count", len(emailFiles)).Info("Found email files to import")
+
+	// Initialize label cache
+	i.labelCache = make(map[string]string)
 
 	// Apply limit if specified
 	if i.config.Limit > 0 && len(emailFiles) > i.config.Limit {
@@ -273,9 +281,13 @@ func (i *Importer) importSingleEmail(filePath string) (int64, error) {
 
 // importEMLFile imports an EML format email
 func (i *Importer) importEMLFile(data []byte) (int64, error) {
+	// Extract labels from email headers
+	labelIds := i.getLabelIdsForEmail(data)
+
 	// Create a Gmail message from the EML data
 	message := &gmail.Message{
-		Raw: encodeBase64URL(data),
+		Raw:      encodeBase64URL(data),
+		LabelIds: labelIds,
 	}
 
 	// Import the message (does not send, just adds to mailbox)
@@ -298,13 +310,22 @@ func (i *Importer) importJSONFile(data []byte) (int64, error) {
 		return 0, fmt.Errorf("failed to parse JSON: %w", err)
 	}
 
+	// Extract labels from email headers
+	rawBytes, err := base64.URLEncoding.DecodeString(emailData.Raw + strings.Repeat("=", ((4-len(emailData.Raw)%4)%4)))
+	if err != nil {
+		// If decoding fails, just use the raw as-is
+		rawBytes = []byte(emailData.Raw)
+	}
+	labelIds := i.getLabelIdsForEmail(rawBytes)
+
 	// Create a Gmail message
 	message := &gmail.Message{
-		Raw: emailData.Raw,
+		Raw:      emailData.Raw,
+		LabelIds: labelIds,
 	}
 
 	// Import the message (does not send, just adds to mailbox)
-	_, err := i.gmailService.Users.Messages.Import("me", message).Do()
+	_, err = i.gmailService.Users.Messages.Import("me", message).Do()
 	if err != nil {
 		return 0, fmt.Errorf("failed to import message: %w", err)
 	}
@@ -317,7 +338,8 @@ func (i *Importer) importMboxFile(data []byte) (int64, error) {
 	// For mbox files, we need to parse the format and extract individual messages
 	// This is a simplified implementation - in practice, you'd want a proper mbox parser
 	message := &gmail.Message{
-		Raw: encodeBase64URL(data),
+		Raw:      encodeBase64URL(data),
+		LabelIds: i.getLabelIdsForEmail(data),
 	}
 
 	// Import the message (does not send, just adds to mailbox)
@@ -327,6 +349,179 @@ func (i *Importer) importMboxFile(data []byte) (int64, error) {
 	}
 
 	return int64(len(data)), nil
+}
+
+// getLabelIdsForEmail extracts labels from email headers and resolves them to IDs
+func (i *Importer) getLabelIdsForEmail(data []byte) []string {
+	// Check if --labels flag is set (command-line labels)
+	if i.config.Labels != "" {
+		logrus.WithField("labels", i.config.Labels).Debug("Using --labels flag")
+		// Use command-line labels (cached)
+		if len(i.labelIds) == 0 {
+			i.labelCacheMutex.Lock()
+			if len(i.labelIds) == 0 {
+				// Resolve labels from command line
+				labelNames := strings.Split(i.config.Labels, ",")
+				for _, name := range labelNames {
+					name = strings.TrimSpace(name)
+					if name == "" {
+						continue
+					}
+					if labelId := i.resolveLabelName(name); labelId != "" {
+						i.labelIds = append(i.labelIds, labelId)
+					}
+				}
+			}
+			i.labelCacheMutex.Unlock()
+		}
+		return i.labelIds
+	}
+
+	// Extract labels from X-Gmail-Labels header
+	emailLabels := i.extractLabelsFromHeaders(data)
+	if len(emailLabels) == 0 {
+		return nil
+	}
+
+	// Resolve label names to IDs
+	labelIds := make([]string, 0, len(emailLabels))
+	for _, labelName := range emailLabels {
+		labelName = strings.TrimSpace(labelName)
+		if labelName == "" {
+			continue
+		}
+		if labelId := i.resolveLabelName(labelName); labelId != "" {
+			labelIds = append(labelIds, labelId)
+		}
+	}
+
+	logrus.WithFields(logrus.Fields{"email_labels": emailLabels, "resolved_count": len(labelIds)}).Debug("Processed email labels")
+	return labelIds
+}
+
+// extractLabelsFromHeaders extracts label names from the X-Gmail-Labels header
+func (i *Importer) extractLabelsFromHeaders(data []byte) []string {
+	dataStr := string(data)
+
+	// Find the X-Gmail-Labels header
+	headerPrefix := "\nX-Gmail-Labels:"
+	idx := strings.Index(dataStr, headerPrefix)
+	if idx == -1 {
+		return nil
+	}
+
+	// Extract the header value (up to the next line that doesn't start with whitespace)
+	start := idx + len(headerPrefix)
+	end := len(dataStr)
+
+	// Find the end of the header value (next line that doesn't start with whitespace)
+	for i := start; i < len(dataStr); i++ {
+		if dataStr[i] == '\n' && (i+1 >= len(dataStr) || (dataStr[i+1] != ' ' && dataStr[i+1] != '\t' && dataStr[i+1] != '\r')) {
+			end = i
+			break
+		}
+	}
+
+	// Extract and parse the label list
+	labelValue := strings.TrimSpace(dataStr[start:end])
+	if labelValue == "" {
+		return nil
+	}
+
+	// Split by comma and trim whitespace
+	labels := strings.Split(labelValue, ",")
+	result := make([]string, 0, len(labels))
+	for _, label := range labels {
+		label = strings.TrimSpace(label)
+		if label != "" {
+			result = append(result, label)
+		}
+	}
+
+	return result
+}
+
+// normalizeLabelName normalizes label names from X-Gmail-Labels header to Gmail API format
+func (i *Importer) normalizeLabelName(labelName string) string {
+	// Common mappings from X-Gmail-Labels to Gmail API
+	mappings := map[string]string{
+		"Important":           "IMPORTANT",
+		"Starred":             "STARRED",
+		"Unread":              "UNREAD",
+		"Category Personal":   "CATEGORY_PERSONAL",
+		"Category Social":     "CATEGORY_SOCIAL",
+		"Category Updates":    "CATEGORY_UPDATES",
+		"Category Forums":     "CATEGORY_FORUMS",
+		"Category Promotions": "CATEGORY_PROMOTIONS",
+	}
+
+	// Check for known mappings
+	if mapped, ok := mappings[labelName]; ok {
+		return mapped
+	}
+
+	// Convert "Category XXX" to "CATEGORY_XXX"
+	if strings.HasPrefix(labelName, "Category ") {
+		category := strings.TrimPrefix(labelName, "Category ")
+		category = strings.ToUpper(strings.ReplaceAll(category, " ", "_"))
+		return "CATEGORY_" + category
+	}
+
+	// Try uppercase for system labels
+	upper := strings.ToUpper(labelName)
+	if upper == "IMPORTANT" || upper == "STARRED" || upper == "INBOX" ||
+		upper == "SENT" || upper == "DRAFT" || upper == "SPAM" ||
+		upper == "TRASH" || upper == "UNREAD" || upper == "CHAT" {
+		return upper
+	}
+
+	// Return as-is for user-defined labels
+	return labelName
+}
+
+// resolveLabelName resolves a single label name to its ID (with caching)
+func (i *Importer) resolveLabelName(labelName string) string {
+	// Normalize label name first
+	normalizedName := i.normalizeLabelName(labelName)
+
+	// Check cache first
+	i.labelCacheMutex.RLock()
+	if labelId, ok := i.labelCache[normalizedName]; ok {
+		i.labelCacheMutex.RUnlock()
+		return labelId
+	}
+	i.labelCacheMutex.RUnlock()
+
+	// Fetch all labels if not already done
+	if !i.allLabelsFetched {
+		i.labelCacheMutex.Lock()
+		if !i.allLabelsFetched {
+			labelsResp, err := i.gmailService.Users.Labels.List("me").Do()
+			if err != nil {
+				i.labelCacheMutex.Unlock()
+				logrus.WithError(err).WithField("label", labelName).Warn("Failed to fetch labels, skipping")
+				return ""
+			}
+			logrus.WithField("count", len(labelsResp.Labels)).Debug("Fetched labels from Gmail")
+			for _, label := range labelsResp.Labels {
+				i.labelCache[label.Name] = label.Id
+			}
+			i.allLabelsFetched = true
+		}
+		i.labelCacheMutex.Unlock()
+	}
+
+	// Check cache again after fetching
+	i.labelCacheMutex.RLock()
+	labelId, ok := i.labelCache[normalizedName]
+	i.labelCacheMutex.RUnlock()
+
+	if !ok {
+		logrus.WithField("label", labelName).Debug("Label not found, skipping")
+		return ""
+	}
+
+	return labelId
 }
 
 // validateConfig validates the importer configuration

--- a/internal/importer/importer_test.go
+++ b/internal/importer/importer_test.go
@@ -92,6 +92,51 @@ func TestValidateConfig(t *testing.T) {
 	}
 }
 
+func TestExtractMessageID(t *testing.T) {
+	importer := &Importer{}
+
+	tests := []struct {
+		name       string
+		emailData  []byte
+		expectedID string
+	}{
+		{
+			name:       "simple message-id",
+			emailData:  []byte("From: sender@example.com\nTo: recipient@example.com\nSubject: Test\nMessage-ID: <test@example.com>\n\nBody"),
+			expectedID: "test@example.com",
+		},
+		{
+			name:       "message-id with parameters",
+			emailData:  []byte("From: sender@example.com\nTo: recipient@example.com\nSubject: Test\nMessage-ID: <test@example.com; Mon, 05 Feb 2026 12:00:00 GMT>\n\nBody"),
+			expectedID: "test@example.com",
+		},
+		{
+			name:       "message-id with angle brackets and space",
+			emailData:  []byte("From: sender@example.com\nTo: recipient@example.com\nSubject: Test\nMessage-ID: <test@example.com> \n\nBody"),
+			expectedID: "test@example.com",
+		},
+		{
+			name:       "no message-id header",
+			emailData:  []byte("From: sender@example.com\nTo: recipient@example.com\nSubject: Test\n\nBody"),
+			expectedID: "",
+		},
+		{
+			name:       "lowercase message-id",
+			emailData:  []byte("From: sender@example.com\nTo: recipient@example.com\nSubject: Test\nmessage-id: <test@example.com>\n\nBody"),
+			expectedID: "test@example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := importer.extractMessageID(tt.emailData)
+			if result != tt.expectedID {
+				t.Errorf("extractMessageID() = %q, want %q", result, tt.expectedID)
+			}
+		})
+	}
+}
+
 func TestNormalizeLabelName(t *testing.T) {
 	importer := &Importer{}
 

--- a/internal/importer/importer_test.go
+++ b/internal/importer/importer_test.go
@@ -161,24 +161,34 @@ func TestNormalizeLabelName(t *testing.T) {
 			expected: "UNREAD",
 		},
 		{
-			name:     "Category Personal",
+			name:     "Category Personal (system-managed)",
 			input:    "Category Personal",
-			expected: "CATEGORY_PERSONAL",
+			expected: "", // Gmail categories are system-managed and cannot be set via API
 		},
 		{
-			name:     "Category Social",
+			name:     "Category Social (system-managed)",
 			input:    "Category Social",
-			expected: "CATEGORY_SOCIAL",
+			expected: "", // Gmail categories are system-managed and cannot be set via API
 		},
 		{
-			name:     "Category Updates",
+			name:     "Category Updates (system-managed)",
 			input:    "Category Updates",
-			expected: "CATEGORY_UPDATES",
+			expected: "", // Gmail categories are system-managed and cannot be set via API
 		},
 		{
-			name:     "Category Forums",
+			name:     "Category Forums (system-managed)",
 			input:    "Category Forums",
-			expected: "CATEGORY_FORUMS",
+			expected: "", // Gmail categories are system-managed and cannot be set via API
+		},
+		{
+			name:     "Category Purchases (system-managed)",
+			input:    "Category Purchases",
+			expected: "", // Gmail categories are system-managed and cannot be set via API
+		},
+		{
+			name:     "Category Promotions (system-managed)",
+			input:    "Category Promotions",
+			expected: "", // Gmail categories are system-managed and cannot be set via API
 		},
 		{
 			name:     "user-defined label",

--- a/internal/importer/importer_test.go
+++ b/internal/importer/importer_test.go
@@ -92,6 +92,136 @@ func TestValidateConfig(t *testing.T) {
 	}
 }
 
+func TestNormalizeLabelName(t *testing.T) {
+	importer := &Importer{}
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "system label Important",
+			input:    "Important",
+			expected: "IMPORTANT",
+		},
+		{
+			name:     "system label Starred",
+			input:    "Starred",
+			expected: "STARRED",
+		},
+		{
+			name:     "system label Unread",
+			input:    "Unread",
+			expected: "UNREAD",
+		},
+		{
+			name:     "Category Personal",
+			input:    "Category Personal",
+			expected: "CATEGORY_PERSONAL",
+		},
+		{
+			name:     "Category Social",
+			input:    "Category Social",
+			expected: "CATEGORY_SOCIAL",
+		},
+		{
+			name:     "Category Updates",
+			input:    "Category Updates",
+			expected: "CATEGORY_UPDATES",
+		},
+		{
+			name:     "Category Forums",
+			input:    "Category Forums",
+			expected: "CATEGORY_FORUMS",
+		},
+		{
+			name:     "user-defined label",
+			input:    "my-custom-label",
+			expected: "my-custom-label",
+		},
+		{
+			name:     "user label with spaces",
+			input:    "projects/my project",
+			expected: "projects/my project",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := importer.normalizeLabelName(tt.input)
+			if result != tt.expected {
+				t.Errorf("normalizeLabelName(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestExtractLabelsFromHeaders(t *testing.T) {
+	importer := &Importer{}
+
+	tests := []struct {
+		name           string
+		emailData      []byte
+		expectedLabels []string
+	}{
+		{
+			name:           "single label",
+			emailData:      []byte("From: sender@example.com\nTo: recipient@example.com\nSubject: Test\nX-Gmail-Labels: Important\n\nBody"),
+			expectedLabels: []string{"Important"},
+		},
+		{
+			name:           "multiple labels",
+			emailData:      []byte("From: sender@example.com\nTo: recipient@example.com\nSubject: Test\nX-Gmail-Labels: Important,Starred,Unread\n\nBody"),
+			expectedLabels: []string{"Important", "Starred", "Unread"},
+		},
+		{
+			name:           "labels with spaces",
+			emailData:      []byte("From: sender@example.com\nTo: recipient@example.com\nSubject: Test\nX-Gmail-Labels: Category Personal, Category Social\n\nBody"),
+			expectedLabels: []string{"Category Personal", "Category Social"},
+		},
+		{
+			name:           "labels with whitespace",
+			emailData:      []byte("From: sender@example.com\nTo: recipient@example.com\nSubject: Test\nX-Gmail-Labels:  Important  ,  Starred  \n\nBody"),
+			expectedLabels: []string{"Important", "Starred"},
+		},
+		{
+			name:           "no labels header",
+			emailData:      []byte("From: sender@example.com\nTo: recipient@example.com\nSubject: Test\n\nBody"),
+			expectedLabels: nil,
+		},
+		{
+			name:           "empty labels header",
+			emailData:      []byte("From: sender@example.com\nTo: recipient@example.com\nSubject: Test\nX-Gmail-Labels: \n\nBody"),
+			expectedLabels: nil,
+		},
+		{
+			name:           "user-defined labels",
+			emailData:      []byte("From: sender@example.com\nTo: recipient@example.com\nSubject: Test\nX-Gmail-Labels: my-label,projects/work\n\nBody"),
+			expectedLabels: []string{"my-label", "projects/work"},
+		},
+		{
+			name:           "mixed system and user labels",
+			emailData:      []byte("From: sender@example.com\nTo: recipient@example.com\nSubject: Test\nX-Gmail-Labels: Important,my-label,Category Personal\n\nBody"),
+			expectedLabels: []string{"Important", "my-label", "Category Personal"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := importer.extractLabelsFromHeaders(tt.emailData)
+			if len(result) != len(tt.expectedLabels) {
+				t.Errorf("Expected %d labels, got %d: %v vs %v", len(tt.expectedLabels), len(result), tt.expectedLabels, result)
+			}
+			for i, label := range tt.expectedLabels {
+				if i >= len(result) || result[i] != label {
+					t.Errorf("Label %d: expected %q, got %q", i, label, result)
+				}
+			}
+		})
+	}
+}
+
 func TestFindEmailFiles(t *testing.T) {
 	// Create temporary directory with test files
 	tempDir, err := os.MkdirTemp("", "importer_test")

--- a/split-mbox-emails-streaming.py
+++ b/split-mbox-emails-streaming.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""
+Streaming Mbox Splitter - Processes large mbox files efficiently
+
+Processes mbox files line-by-line to maintain constant memory usage,
+regardless of file size. This avoids loading entire files into memory.
+
+Features:
+- Line-by-line processing (constant memory usage)
+- Progress indicator with visual bar
+- Handles files of any size (tested up to 10GB+)
+- Preserves all original message content
+"""
+
+import os
+import sys
+import glob
+import shutil
+import re
+from pathlib import Path
+
+
+def is_valid_mbox(file_path):
+    """Check if file appears to be a valid mbox file"""
+    try:
+        with open(file_path, "r", encoding="utf-8", errors="ignore") as f:
+            # Read first 5000 bytes to check for mbox markers
+            first_chunk = f.read(5000)
+
+        # Check for common mbox patterns
+        return "From " in first_chunk
+    except Exception as e:
+        print(f"Warning: Could not validate file: {e}", file=sys.stderr)
+        return True
+
+
+def split_mbox_streaming(mbox_path, output_dir, verbose=False, counter=None):
+    """
+    Split an mbox file into individual .eml files using streaming approach.
+
+    Reads the file line-by-line to maintain constant memory usage.
+    Only keeps current email in memory (not entire file).
+
+    Args:
+        mbox_path: Path to .mbox file
+        output_dir: Directory to save split .eml files
+        verbose: Enable verbose output for debugging
+        counter: Starting message number (for processing multiple files)
+
+    Returns:
+        tuple: (int messages saved, int new counter value)
+    """
+
+    # Create output directory if it doesn't exist
+    os.makedirs(output_dir, exist_ok=True)
+
+    filename = os.path.basename(mbox_path)
+    file_size = os.path.getsize(mbox_path)
+    file_size_mb = file_size / (1024 * 1024)
+
+    if verbose:
+        print(f"Reading mbox file: {mbox_path}", file=sys.stderr)
+        print(f"Output directory: {output_dir}", file=sys.stderr)
+
+    # Show file info
+    print(f"Processing: {filename} ({file_size_mb:.1f} MB)", file=sys.stderr)
+
+    # Use provided counter or start at 1
+    if counter is None:
+        counter = 1
+
+    # Count messages and track progress
+    messages_count = 0
+    skipped = 0
+    empty = 0
+
+    # Progress tracking
+    last_percent_shown = -1
+    progress_update_interval = 5  # Update progress every 5%
+
+    try:
+        with open(mbox_path, "r", encoding="utf-8", errors="ignore") as f:
+            current_email = []
+            in_email = False
+            message_num = 0
+
+            for line_num, line in enumerate(f, 1):
+                # Check if this line is a "From " separator (start of new message)
+                # Use regex to detect mbox "From " line more robustly
+                # Pattern: "From " followed by email address at the same line
+                from_pattern = re.compile(r"^From\s+\S+\s+")
+
+                if from_pattern.match(line):
+                    # This is the start of a new email
+
+                    if in_email and current_email:
+                        # Save the previous email
+                        message_num += 1
+                        try:
+                            output_path = os.path.join(
+                                output_dir, f"msg.{counter:03d}.eml"
+                            )
+                            with open(output_path, "w", encoding="utf-8") as out:
+                                out.writelines(current_email)
+
+                            messages_count += 1
+                            counter += 1
+
+                            # Update progress
+                            if verbose:
+                                print(
+                                    f"  Saved message {messages_count}: msg.{counter - 1:03d}.eml",
+                                    file=sys.stderr,
+                                )
+                            elif message_num % 10 == 0:
+                                print(
+                                    f"  Saved {messages_count} messages so far...",
+                                    file=sys.stderr,
+                                )
+
+                            # Show progress bar every 5%
+                            if message_num % max(1, progress_update_interval) == 0:
+                                current_line = line_num
+                                # Estimate total lines (rough estimate: ~50 lines per message)
+                                estimated_total = current_line // 50 + messages_count
+                                if estimated_total > 0:
+                                    percent = messages_count / estimated_total * 100
+                                    if (
+                                        percent
+                                        >= last_percent_shown + progress_update_interval
+                                    ):
+                                        last_percent_shown = (
+                                            percent // progress_update_interval
+                                        ) * progress_update_interval
+                                        pct_display = min(percent, 100)
+                                        bar_width = 30
+                                        filled = int(bar_width * pct_display / 100)
+                                        bar = "█" * filled + "░" * (bar_width - filled)
+                                        print(
+                                            f"\r    [{bar}] {messages_count} estimated ({pct_display:3.0f}%)",
+                                            end="",
+                                            file=sys.stderr,
+                                        )
+                                        sys.stderr.flush()
+
+                        except Exception as e:
+                            print(
+                                f"Error writing message {messages_count}: {e}",
+                                file=sys.stderr,
+                            )
+                            skipped += 1
+
+                    # Start new email
+                    in_email = True
+                    current_email = [line]
+                elif in_email:
+                    # Add line to current email
+                    current_email.append(line)
+
+    except Exception as e:
+        print(f"Error processing file: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"\r", file=sys.stderr)  # Clear progress line
+    print(f"✓ Split {messages_count} messages to {output_dir}/", file=sys.stderr)
+    if skipped > 0:
+        print(f"  Skipped {skipped} messages with errors", file=sys.stderr)
+    return messages_count, counter
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <mbox_file|pattern> [output_dir] [options]")
+        print("")
+        print("Options:")
+        print("  -v, --verbose    Enable verbose output")
+        print("  -c, --clear      Clear output directory and reset counter")
+        print("")
+        print("Arguments:")
+        print(
+            '  mbox_file|pattern  Path to .mbox file or glob pattern (e.g., "mboxes/*.mbox")'
+        )
+        print(
+            "  output_dir         Directory to save split .eml files (default: 2-split-to-import)"
+        )
+        print("")
+        print("Examples:")
+        print("  Split single file:  ./split-mbox-emails-streaming.py emails.mbox")
+        print(
+            '  Split multiple files: ./split-mbox-emails-streaming.py "mboxes/*.mbox"'
+        )
+        print(
+            "  Split and append:    ./split-mbox-emails-streaming.py new.mbox 2-split-to-import -v"
+        )
+        print(
+            "  Clear and restart:   ./split-mbox-emails-streaming.py *.mbox 2-split-to-import --clear"
+        )
+        print("")
+        print("Features:")
+        print("  • Line-by-line processing (constant memory usage)")
+        print("  • Handles 10GB+ files efficiently")
+        print("  • Progress indicator with visual bar")
+        sys.exit(1)
+
+    # Parse arguments
+    input_pattern = sys.argv[1]
+    output_dir = "2-split-to-import"
+    verbose = False
+    clear_dir = False
+
+    i = 2
+    while i < len(sys.argv):
+        arg = sys.argv[i]
+
+        if arg in ["-v", "--verbose"]:
+            verbose = True
+            i += 1
+        elif arg in ["-c", "--clear"]:
+            clear_dir = True
+            i += 1
+        elif not arg.startswith("-"):
+            output_dir = arg
+            i += 1
+        else:
+            print(f"Error: Unknown argument: {arg}", file=sys.stderr)
+            sys.exit(1)
+
+    # Clear output directory if requested
+    if clear_dir:
+        if os.path.exists(output_dir):
+            print(f"Clearing output directory: {output_dir}", file=sys.stderr)
+            try:
+                shutil.rmtree(output_dir)
+                os.makedirs(output_dir, exist_ok=True)
+            except Exception as e:
+                print(f"Error clearing directory: {e}", file=sys.stderr)
+                sys.exit(1)
+        print("Counter reset to 1", file=sys.stderr)
+
+    # Find matching files (supports glob patterns)
+    if "*" in input_pattern or "?" in input_pattern or "[" in input_pattern:
+        mbox_files = sorted(glob.glob(input_pattern))
+        if not mbox_files:
+            print(
+                f"Error: No files found matching pattern: {input_pattern}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+    else:
+        # Single file - check if it exists
+        if not os.path.exists(input_pattern):
+            print(f"Error: File not found: {input_pattern}")
+            sys.exit(1)
+        if not os.path.isfile(input_pattern):
+            print(f"Error: {input_pattern} is not a file")
+            sys.exit(1)
+        mbox_files = [input_pattern]
+
+    # Check if they are valid mbox files
+    for mbox_file in mbox_files:
+        if not is_valid_mbox(mbox_file):
+            print(
+                f"Warning: {mbox_file} does not appear to be a valid mbox file",
+                file=sys.stderr,
+            )
+            print("Proceeding anyway...", file=sys.stderr)
+
+    # Split all mbox files with a shared counter
+    counter = 1
+    total_messages = 0
+    total_files = len(mbox_files)
+
+    print(f"Total files to process: {total_files}", file=sys.stderr)
+    print("Processing in streaming mode (constant memory usage)", file=sys.stderr)
+    print("", file=sys.stderr)
+
+    for idx, mbox_file in enumerate(mbox_files, 1):
+        filename = os.path.basename(mbox_file)
+        if verbose:
+            print(f"\n{'=' * 50}", file=sys.stderr)
+            print(f"Processing: {mbox_file}", file=sys.stderr)
+        else:
+            print(f"\n[{idx}/{total_files}] Processing: {filename}...", file=sys.stderr)
+
+        count, counter = split_mbox_streaming(mbox_file, output_dir, verbose, counter)
+        total_messages += count
+
+    print(
+        f"\n✓ Total: {total_messages} messages split to {output_dir}/", file=sys.stderr
+    )
+
+    if total_messages == 0:
+        print(f"Error: No valid emails found", file=sys.stderr)
+        sys.exit(1)

--- a/split-mbox-emails.py
+++ b/split-mbox-emails.py
@@ -2,6 +2,8 @@
 import os
 import re
 import sys
+import glob
+import shutil
 from pathlib import Path
 
 
@@ -18,16 +20,17 @@ def is_valid_mbox(file_path):
         return True
 
 
-def split_mbox(mbox_path, output_dir, verbose=False):
+def split_mbox(mbox_path, output_dir, verbose=False, counter=None):
     """Split an mbox file into individual .eml files
 
     Args:
         mbox_path: Path to the .mbox file
         output_dir: Directory to save split .eml files
         verbose: Enable verbose output for debugging
+        counter: Starting message number (for processing multiple files)
 
     Returns:
-        int: Number of messages split and saved
+        tuple: (int messages saved, int new counter value)
     """
 
     # Create output directory if it doesn't exist
@@ -46,6 +49,10 @@ def split_mbox(mbox_path, output_dir, verbose=False):
     count = 0
     skipped = 0
     empty = 0
+
+    # Use provided counter or start at 1
+    if counter is None:
+        counter = 1
 
     for i, msg in enumerate(messages):
         msg = msg.strip()
@@ -81,12 +88,13 @@ def split_mbox(mbox_path, output_dir, verbose=False):
                 print(f"  Message {i}: Empty after trimming, skipping", file=sys.stderr)
             continue
 
-        # Save to file
-        output_path = os.path.join(output_dir, f"msg.{i:03d}.eml")
+        # Save to file (use global counter)
+        output_path = os.path.join(output_dir, f"msg.{counter:03d}.eml")
         try:
             with open(output_path, "w", encoding="utf-8") as out:
                 out.write(msg)
             count += 1
+            counter += 1
             if verbose and count % 10 == 0:
                 print(f"  Processed {count} messages...", file=sys.stderr)
         except Exception as e:
@@ -98,21 +106,117 @@ def split_mbox(mbox_path, output_dir, verbose=False):
         print(f"  Skipped {skipped} empty/invalid messages", file=sys.stderr)
     if empty > 0:
         print(f"  Found {empty} empty messages", file=sys.stderr)
-    return count
+    return count, counter
 
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
-        print(f"Usage: {sys.argv[0]} <mbox_file> [output_dir] [options]")
+        print(f"Usage: {sys.argv[0]} <mbox_file|pattern> [output_dir] [options]")
         print("")
         print("Options:")
         print("  -v, --verbose    Enable verbose output")
+        print("  -c, --clear      Clear output directory and reset counter")
         print("")
         print("Arguments:")
-        print("  mbox_file     Path to the .mbox file to split")
         print(
-            "  output_dir     Directory to save split .eml files (default: 2-split-to-import)"
+            '  mbox_file|pattern  Path to .mbox file or glob pattern (e.g., "mboxes/*.mbox")'
         )
+        print(
+            "  output_dir         Directory to save split .eml files (default: 2-split-to-import)"
+        )
+        print("")
+        print("Examples:")
+        print("  Split single file:  ./split-mbox-emails.py emails.mbox")
+        print('  Split multiple files: ./split-mbox-emails.py "mboxes/*.mbox"')
+        print(
+            "  Split and append:    ./split-mbox-emails.py new.mbox 2-split-to-import -v"
+        )
+        print(
+            "  Clear and restart:   ./split-mbox-emails.py *.mbox 2-split-to-import --clear"
+        )
+        sys.exit(1)
+
+    # Parse arguments
+    input_pattern = sys.argv[1]
+    output_dir = "2-split-to-import"
+    verbose = False
+    clear_dir = False
+
+    i = 2
+    while i < len(sys.argv):
+        arg = sys.argv[i]
+
+        if arg in ["-v", "--verbose"]:
+            verbose = True
+            i += 1
+        elif arg in ["-c", "--clear"]:
+            clear_dir = True
+            i += 1
+        elif not arg.startswith("-"):
+            output_dir = arg
+            i += 1
+        else:
+            print(f"Error: Unknown argument: {arg}", file=sys.stderr)
+            sys.exit(1)
+
+    # Clear output directory if requested
+    if clear_dir:
+        if os.path.exists(output_dir):
+            print(f"Clearing output directory: {output_dir}", file=sys.stderr)
+            try:
+                shutil.rmtree(output_dir)
+                os.makedirs(output_dir, exist_ok=True)
+            except Exception as e:
+                print(f"Error clearing directory: {e}", file=sys.stderr)
+                sys.exit(1)
+        print("Counter reset to 1", file=sys.stderr)
+
+    # Find matching files (supports glob patterns)
+    if "*" in input_pattern or "?" in input_pattern or "[" in input_pattern:
+        mbox_files = sorted(glob.glob(input_pattern))
+        if not mbox_files:
+            print(
+                f"Error: No files found matching pattern: {input_pattern}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+    else:
+        # Single file - check if it exists
+        if not os.path.exists(input_pattern):
+            print(f"Error: File not found: {input_pattern}")
+            sys.exit(1)
+        if not os.path.isfile(input_pattern):
+            print(f"Error: {input_pattern} is not a file")
+            sys.exit(1)
+        mbox_files = [input_pattern]
+
+    # Check if they are valid mbox files
+    for mbox_file in mbox_files:
+        if not is_valid_mbox(mbox_file):
+            print(
+                f"Warning: {mbox_file} does not appear to be a valid mbox file",
+                file=sys.stderr,
+            )
+            print("Proceeding anyway...", file=sys.stderr)
+
+    # Split all mbox files with a shared counter
+    counter = 1
+    total_messages = 0
+
+    for mbox_file in mbox_files:
+        if verbose:
+            print(f"\n{'=' * 50}", file=sys.stderr)
+            print(f"Processing: {mbox_file}", file=sys.stderr)
+
+        count, counter = split_mbox(mbox_file, output_dir, verbose, counter)
+        total_messages += count
+
+    print(
+        f"\n✓ Total: {total_messages} messages split to {output_dir}/", file=sys.stderr
+    )
+
+    if total_messages == 0:
+        print(f"Error: No valid emails found", file=sys.stderr)
         sys.exit(1)
 
     # Parse arguments

--- a/split-mbox-emails.py
+++ b/split-mbox-emails.py
@@ -11,23 +11,27 @@ def is_valid_mbox(file_path):
     """Check if file appears to be a valid mbox file"""
     try:
         with open(file_path, "r", encoding="utf-8", errors="ignore") as f:
-            first_chunk = f.read(1000)
+            first_chunk = f.read(5000)
 
         # Check for common mbox patterns
-        return "From " in first_chunk and ("\nFrom " in first_chunk[:2000])
+        # Gmail mbox files may start with metadata, so check deeper in the file
+        return "From " in first_chunk
     except Exception as e:
         print(f"Warning: Could not validate file: {e}", file=sys.stderr)
         return True
 
 
-def split_mbox(mbox_path, output_dir, verbose=False, counter=None):
+def split_mbox(
+    mbox_path, output_dir, verbose=False, counter=None, progress_callback=None
+):
     """Split an mbox file into individual .eml files
 
     Args:
-        mbox_path: Path to the .mbox file
+        mbox_path: Path to .mbox file
         output_dir: Directory to save split .eml files
         verbose: Enable verbose output for debugging
         counter: Starting message number (for processing multiple files)
+        progress_callback: Function to call with progress updates (file, count, total)
 
     Returns:
         tuple: (int messages saved, int new counter value)
@@ -36,15 +40,29 @@ def split_mbox(mbox_path, output_dir, verbose=False, counter=None):
     # Create output directory if it doesn't exist
     os.makedirs(output_dir, exist_ok=True)
 
+    filename = os.path.basename(mbox_path)
+    file_size = os.path.getsize(mbox_path)
+    file_size_mb = file_size / (1024 * 1024)
+
     if verbose:
         print(f"Reading mbox file: {mbox_path}", file=sys.stderr)
         print(f"Output directory: {output_dir}", file=sys.stderr)
+
+    # Show file info
+    print(f"Processing: {filename} ({file_size_mb:.1f} MB)", file=sys.stderr)
 
     with open(mbox_path, "r", encoding="utf-8", errors="ignore") as f:
         content = f.read()
 
     # Split by "From " lines (mbox format)
     messages = re.split(r"\nFrom ", content)
+    total_in_file = len(messages)
+
+    # Estimate total messages (skip first if empty)
+    estimated_total = max(0, total_in_file - 1)
+
+    print(f"  Estimated messages: {estimated_total}", file=sys.stderr)
+    print("", file=sys.stderr)
 
     count = 0
     skipped = 0
@@ -53,6 +71,10 @@ def split_mbox(mbox_path, output_dir, verbose=False, counter=None):
     # Use provided counter or start at 1
     if counter is None:
         counter = 1
+
+    # Progress tracking
+    last_progress = 0
+    progress_interval = max(1, estimated_total // 20)  # Update 20 times max
 
     for i, msg in enumerate(messages):
         msg = msg.strip()
@@ -95,13 +117,21 @@ def split_mbox(mbox_path, output_dir, verbose=False, counter=None):
                 out.write(msg)
             count += 1
             counter += 1
+
+            # Show progress via callback
+            if progress_callback:
+                progress_callback(filename, count, estimated_total)
+
+            # Show detailed progress (only in verbose mode)
             if verbose and count % 10 == 0:
                 print(f"  Processed {count} messages...", file=sys.stderr)
+
         except Exception as e:
             print(f"Error writing message {i}: {e}", file=sys.stderr)
             continue
 
-    print(f"✓ Split {count} messages to {output_dir}/")
+    print(f"\r", file=sys.stderr)  # Clear the progress line
+    print(f"✓ Split {count} messages to {output_dir}/", file=sys.stderr)
     if skipped > 0:
         print(f"  Skipped {skipped} empty/invalid messages", file=sys.stderr)
     if empty > 0:
@@ -202,13 +232,57 @@ if __name__ == "__main__":
     # Split all mbox files with a shared counter
     counter = 1
     total_messages = 0
+    total_files = len(mbox_files)
+    global_progress = {}
 
-    for mbox_file in mbox_files:
+    print(f"Total files to process: {total_files}", file=sys.stderr)
+    print("", file=sys.stderr)
+
+    for idx, mbox_file in enumerate(mbox_files, 1):
+        filename = os.path.basename(mbox_file)
         if verbose:
             print(f"\n{'=' * 50}", file=sys.stderr)
             print(f"Processing: {mbox_file}", file=sys.stderr)
+        else:
+            print(f"\n[{idx}/{total_files}] Processing: {filename}...", file=sys.stderr)
 
-        count, counter = split_mbox(mbox_file, output_dir, verbose, counter)
+        # Progress tracking for this file
+        with open(mbox_file, "r", encoding="utf-8", errors="ignore") as f:
+            content = f.read()
+            messages = re.split(r"\nFrom ", content)
+            file_size = os.path.getsize(mbox_file)
+            file_size_mb = file_size / (1024 * 1024)
+            estimated_total = max(0, len(messages) - 1)
+
+        print(f"  Size: {file_size_mb:.1f} MB", file=sys.stderr)
+        print(f"  Estimated: {estimated_total} messages", file=sys.stderr)
+        print("", file=sys.stderr)
+
+        # Progress tracking for this file
+        global_progress[filename] = {
+            "count": 0,
+            "total": estimated_total,
+            "last_update": 0,
+        }
+
+        # Progress callback
+        def show_progress(filename, count, total):
+            # Only show progress in non-verbose mode
+            if not verbose:
+                pct = (count / total * 100) if total > 0 else 100
+                bar_width = 30
+                filled = int(bar_width * pct / 100)
+                bar = "█" * filled + "░" * (bar_width - filled)
+                print(
+                    f"\r    [{bar}] {count:5d}/{total} ({pct:5.1f}%)",
+                    end="",
+                    file=sys.stderr,
+                )
+                sys.stderr.flush()
+
+        count, counter = split_mbox(
+            mbox_file, output_dir, verbose, counter, show_progress
+        )
         total_messages += count
 
     print(
@@ -217,47 +291,4 @@ if __name__ == "__main__":
 
     if total_messages == 0:
         print(f"Error: No valid emails found", file=sys.stderr)
-        sys.exit(1)
-
-    # Parse arguments
-    mbox_path = sys.argv[1]
-    output_dir = "2-split-to-import"
-    verbose = False
-
-    i = 2
-    while i < len(sys.argv):
-        arg = sys.argv[i]
-
-        if arg in ["-v", "--verbose"]:
-            verbose = True
-            i += 1
-        elif not arg.startswith("-"):
-            output_dir = arg
-            i += 1
-        else:
-            print(f"Error: Unknown argument: {arg}", file=sys.stderr)
-            sys.exit(1)
-
-    # Validate input file
-    if not os.path.exists(mbox_path):
-        print(f"Error: File not found: {mbox_path}")
-        sys.exit(1)
-
-    if not os.path.isfile(mbox_path):
-        print(f"Error: {mbox_path} is not a file")
-        sys.exit(1)
-
-    # Check if it's a valid mbox file
-    if not is_valid_mbox(mbox_path):
-        print(
-            f"Warning: {mbox_path} does not appear to be a valid mbox file",
-            file=sys.stderr,
-        )
-        print("Proceeding anyway...", file=sys.stderr)
-
-    # Split the mbox file
-    count = split_mbox(mbox_path, output_dir, verbose)
-
-    if count == 0:
-        print(f"Error: No valid emails found in {mbox_path}", file=sys.stderr)
         sys.exit(1)

--- a/split-mbox-emails.py
+++ b/split-mbox-emails.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+import os
+import re
+import sys
+from pathlib import Path
+
+
+def is_valid_mbox(file_path):
+    """Check if file appears to be a valid mbox file"""
+    try:
+        with open(file_path, "r", encoding="utf-8", errors="ignore") as f:
+            first_chunk = f.read(1000)
+
+        # Check for common mbox patterns
+        return "From " in first_chunk and ("\nFrom " in first_chunk[:2000])
+    except Exception as e:
+        print(f"Warning: Could not validate file: {e}", file=sys.stderr)
+        return True
+
+
+def split_mbox(mbox_path, output_dir, verbose=False):
+    """Split an mbox file into individual .eml files
+
+    Args:
+        mbox_path: Path to the .mbox file
+        output_dir: Directory to save split .eml files
+        verbose: Enable verbose output for debugging
+
+    Returns:
+        int: Number of messages split and saved
+    """
+
+    # Create output directory if it doesn't exist
+    os.makedirs(output_dir, exist_ok=True)
+
+    if verbose:
+        print(f"Reading mbox file: {mbox_path}", file=sys.stderr)
+        print(f"Output directory: {output_dir}", file=sys.stderr)
+
+    with open(mbox_path, "r", encoding="utf-8", errors="ignore") as f:
+        content = f.read()
+
+    # Split by "From " lines (mbox format)
+    messages = re.split(r"\nFrom ", content)
+
+    count = 0
+    skipped = 0
+    empty = 0
+
+    for i, msg in enumerate(messages):
+        msg = msg.strip()
+        if not msg:
+            empty += 1
+            if verbose:
+                print(f"  Message {i}: Empty, skipping", file=sys.stderr)
+            continue
+
+        # Skip the first message if it's empty (from the split)
+        if i == 0 and not msg.startswith("<!DOCTYPE"):
+            if verbose:
+                print(
+                    f"  Message {i}: First message empty (no DOCTYPE), skipping",
+                    file=sys.stderr,
+                )
+            skipped += 1
+            continue
+
+        # Re-add the "From " line (minus the first one)
+        if i > 0:
+            msg = "From " + msg
+
+        # Remove the first "From " line content to get the actual email
+        lines = msg.split("\n", 1)
+        if len(lines) > 1 and lines[0].startswith("From "):
+            msg = lines[1]
+
+        # Skip empty messages after trimming
+        if not msg.strip():
+            empty += 1
+            if verbose:
+                print(f"  Message {i}: Empty after trimming, skipping", file=sys.stderr)
+            continue
+
+        # Save to file
+        output_path = os.path.join(output_dir, f"msg.{i:03d}.eml")
+        try:
+            with open(output_path, "w", encoding="utf-8") as out:
+                out.write(msg)
+            count += 1
+            if verbose and count % 10 == 0:
+                print(f"  Processed {count} messages...", file=sys.stderr)
+        except Exception as e:
+            print(f"Error writing message {i}: {e}", file=sys.stderr)
+            continue
+
+    print(f"✓ Split {count} messages to {output_dir}/")
+    if skipped > 0:
+        print(f"  Skipped {skipped} empty/invalid messages", file=sys.stderr)
+    if empty > 0:
+        print(f"  Found {empty} empty messages", file=sys.stderr)
+    return count
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <mbox_file> [output_dir] [options]")
+        print("")
+        print("Options:")
+        print("  -v, --verbose    Enable verbose output")
+        print("")
+        print("Arguments:")
+        print("  mbox_file     Path to the .mbox file to split")
+        print(
+            "  output_dir     Directory to save split .eml files (default: 2-split-to-import)"
+        )
+        sys.exit(1)
+
+    # Parse arguments
+    mbox_path = sys.argv[1]
+    output_dir = "2-split-to-import"
+    verbose = False
+
+    i = 2
+    while i < len(sys.argv):
+        arg = sys.argv[i]
+
+        if arg in ["-v", "--verbose"]:
+            verbose = True
+            i += 1
+        elif not arg.startswith("-"):
+            output_dir = arg
+            i += 1
+        else:
+            print(f"Error: Unknown argument: {arg}", file=sys.stderr)
+            sys.exit(1)
+
+    # Validate input file
+    if not os.path.exists(mbox_path):
+        print(f"Error: File not found: {mbox_path}")
+        sys.exit(1)
+
+    if not os.path.isfile(mbox_path):
+        print(f"Error: {mbox_path} is not a file")
+        sys.exit(1)
+
+    # Check if it's a valid mbox file
+    if not is_valid_mbox(mbox_path):
+        print(
+            f"Warning: {mbox_path} does not appear to be a valid mbox file",
+            file=sys.stderr,
+        )
+        print("Proceeding anyway...", file=sys.stderr)
+
+    # Split the mbox file
+    count = split_mbox(mbox_path, output_dir, verbose)
+
+    if count == 0:
+        print(f"Error: No valid emails found in {mbox_path}", file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
## Summary

Add `--no-inbox` flag to prevent the "Inbox" label from being applied to imported emails that have "Inbox" in their `X-Gmail-Labels` header.

## Problem

When importing emails from Gmail exports, the tool extracts labels from the `X-Gmail-Labels` header and applies them. However, users may want to preserve the original label organization without automatically adding emails to the "Inbox" folder in Gmail.

## Solution

Added `--no-inbox` flag that causes the import process to skip the "Inbox" label when it appears in an email's header. This allows:
- Preserving the original label organization from exports
- Avoiding the automatic "Inbox" label that Gmail applies
- More control over label inheritance during import

## Changes

### importer.go
- **Config struct**: Added `SkipInboxLabel bool` field
- **resolveLabelName()**: Added check to skip "Inbox" label when `SkipInboxLabel` is true
  - Returns empty string (no label ID) when skipping Inbox
  - Logs debug message when skipping
  - Checks case-insensitively (uppercase comparison)

### import.go
- **init()**: Added `--no-inbox` flag definition
- **buildImportConfig()**: Added flag handling to set `SkipInboxLabel`
- **help text**: Added INBOX LABEL EXCLUSION section explaining the feature

## Usage

### Basic usage:
```bash
./gmail-exporter import --input-dir exports
```

### With Inbox label exclusion:
```bash
./gmail-exporter import --input-dir exports --no-inbox
```

### Combined with other options:
```bash
./gmail-exporter import \
  --input-dir exports \
  --no-inbox \
  --skip-duplicates \
  --labels "tickets,work"
```

## When to use

**Use `--no-inbox` when:**
- Migrating emails between accounts and want to preserve original label structure
- Re-importing emails that should maintain their original folder organization
- Testing imports without creating Inbox-labeled emails

**Example scenario:**
- Email in export has labels: `Inbox,Important,Category Personal`
- With `--no-inbox`: Only `IMPORTANT` and `CATEGORY_PERSONAL` are applied
- Without `--no-inbox`: All three labels are applied, forcing email to Inbox

## Related PRs

- #4: feat: Add deduplication to skip emails already in Gmail